### PR TITLE
(MAINT) Update version pin for pwshlib

### DIFF
--- a/src/internal/functions/Update-PuppetModuleMetadata.ps1
+++ b/src/internal/functions/Update-PuppetModuleMetadata.ps1
@@ -73,7 +73,7 @@ function Update-PuppetModuleMetadata {
     $PuppetMetadata.dependencies = @(
       @{
         name = 'puppetlabs/pwshlib'
-        version_requirement = '>= 0.5.0 < 2.0.0'
+        version_requirement = '>= 0.5.1 < 2.0.0'
       }
     )
     # Update the operating sytem to only support windows *for now*.

--- a/src/tests/functions/Update-PuppetModuleMetadata.Tests.ps1
+++ b/src/tests/functions/Update-PuppetModuleMetadata.Tests.ps1
@@ -74,7 +74,7 @@ Describe 'Update-PuppetModuleMetadata' {
         }
         It 'Updates the dependencies' {
           $Result.dependencies[0].Name | Should -Be 'puppetlabs/pwshlib'
-          $Result.dependencies[0].version_requirement | Should -Be '>= 0.5.0 < 2.0.0'
+          $Result.dependencies[0].version_requirement | Should -Be '>= 0.5.1 < 2.0.0'
         }
         It 'Updates the supported operating system list' {
           $Result.operatingsystem_support[0].operatingsystem | Should -Be 'windows'


### PR DESCRIPTION
This commit updates the version pin for pwshlib to 0.5.1,
which introduces a fix to the base provider which enables
the resources to work properly during a puppet agent run;
prior to that bugfix, they only work via puppet apply.