### PR TITLE
(MAINT) Add project CHANGELOG file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Known limitations section to generated README ([#56](https://github.com/puppetlabs/Puppet.Dsc/pull/56))
+- Function to update Puppet module changelog ([#57](https://github.com/puppetlabs/Puppet.Dsc/pull/57))
+
+### Changed
+
+- Lower bound for `pwshlib-puppetlabs` raised to `0.5.1` ([#55](https://github.com/puppetlabs/Puppet.Dsc/pull/55))
+
+### Fixed
+
+- Correct links in README ([#54](https://github.com/puppetlabs/Puppet.Dsc/pull/54))
+
+## [0.1.0] - 2020-09-25
+
+### Added
+
+- Initial implementation and release
+
+[Unreleased]: https://github.com/puppetlabs/Puppet.Dsc/compare/0.1.0...HEAD
+[0.1.0]: https://github.com/puppetlabs/Puppet.Dsc/releases/tag/0.1.0


### PR DESCRIPTION
This commit adds a changelog to the project in
keeping with the KAC standard and also includes
an unreleased section.

Future pull requests should include, in addition
to documentation and tests, a changelog entry for
the work being done.