### PR TITLE
(MAINT) Enable puppetizing prerelease modules

### DIFF
--- a/src/internal/functions/Add-DscResourceModule.ps1
+++ b/src/internal/functions/Add-DscResourceModule.ps1
@@ -46,7 +46,7 @@ function Add-DscResourceModule {
       if (-not(Test-Path $PathTmp)) {
         $null = New-Item -Path $PathTmp -Force -ItemType 'Directory'
       }
-      Save-Module -Name $Name -Path $PathTmp -RequiredVersion $RequiredVersion -Repository $Repository
+      Save-Module -Name $Name -Path $PathTmp -RequiredVersion $RequiredVersion -Repository $Repository -AllowPrerelease
       ForEach ($ModuleFolder in (Get-ChildItem $PathTmp)) {
         Move-Item -Path (Get-ChildItem $ModuleFolder.FullName).FullName -Destination "$Path/$($ModuleFolder.Name)"
       }


### PR DESCRIPTION
Prior to this commit specifying a module with a prerelease version
would cause an error because the AllowPrerelease flag was not set.

This commit merely enables the puppetizing of prerelease modules but
does not rework the version API to distinguish between them. Because
of the way the modules are currently built, Puppet will not publish
prerelease modules to the forge.

While prerelease versions *can* be used, the maintainers suggest that
this is always a temporary workaround and not a good practice to be
encouraged in production.