### PR TITLE
(GH-66) Ensure type desc strings parse for reference

### DIFF
--- a/src/internal/functions/Get-TypeParameterContent.ps1
+++ b/src/internal/functions/Get-TypeParameterContent.ps1
@@ -28,13 +28,10 @@ Function Get-TypeParameterContent {
       type: $($Parameter.Type -split "`n" -join "`n            "),
 $(
   If ([string]::IsNullOrEmpty($Parameter.Help)) {
-    "      desc: %q{},"
+    "      desc: ' ',"
   } Else {
     # Assemble the Description String with appropriate indentation
-    $DescStrings = @('      desc: %q{')
-    $Parameter.Help.Split("`n") | ForEach-Object -Process {$DescStrings += "        $_"}
-    $DescStrings += '      },'
-    $DescStrings -Join "`n"
+    "      desc: '$($Parameter.Help.Split("`n") -Join ' ')',"
   }
 )
 $(

--- a/src/tests/functions/Get-TypeParameterContent.Tests.ps1
+++ b/src/tests/functions/Get-TypeParameterContent.Tests.ps1
@@ -47,14 +47,14 @@ Describe 'Get-TypeParameterContent' {
         $Result[0] | Should -MatchExactly "mof_type: 'bool',"
         $Result[0] | Should -MatchExactly 'mof_is_embedded: false,'
         $Result[1] | Should -MatchExactly 'dsc_banana: {'
-        $Result[1] | Should -MatchExactly 'desc: %q{},'
+        $Result[1] | Should -MatchExactly "desc: ' ',"
         $Result[1] | Should -MatchExactly 'behaviour: :namevar,'
         $Result[1] | Should -MatchExactly 'mandatory_for_get: true,'
         $Result[1] | Should -MatchExactly 'mandatory_for_set: true,'
         $Result[1] | Should -MatchExactly "mof_type: 'string',"
         $Result[1] | Should -MatchExactly 'mof_is_embedded: false,'
         $Result[2] | Should -MatchExactly 'dsc_cookie: {'
-        $Result[2] | Should -MatchExactly 'desc: %q{},'
+        $Result[2] | Should -MatchExactly "desc: ' ',"
         $Result[2] | Should -MatchExactly 'mandatory_for_get: true,'
         $Result[2] | Should -MatchExactly 'mandatory_for_set: true,'
         $Result[2] | Should -MatchExactly "mof_type: 'string',"


### PR DESCRIPTION
Prior to this commit the desc strings for types were wrapped in `%q{}`, which *should* allow multi-line string description blocks. However, there is a bug in the puppet strings tooling which causes it instead to write the `%q{}` as well as everything inside, which looks _strange_ in the markdown.

This commit modifies the type generation to instead use a single-quoted string for the desc blocks, without newlines. If the help is empty, it now specifies a string with a single whitespace in it.

Failure to include the single whitespace broke puppet strings parsing, so this ensures that no docs are written if they are not specified, keeping the reference documentation readable if not correct from a markdown-linting perspective.

- Resolves #66