### PR TITLE
(GH-94) Add debugging env to vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,4 +61,6 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.provision "shell", path: 'extras/install.ps1'
+  profile_destination = 'C:\Users\vagrant\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1'
+  config.vm.provision "file", source: "./extras/profile.ps1", destination: profile_destination
 end

--- a/extras/install.ps1
+++ b/extras/install.ps1
@@ -5,22 +5,6 @@ $ChocolateyPackages = @(
   'pdk'
 )
 
-if ($ENV:CI -ne 'True') {
-  $ChocolateyPackages += @(
-    'vscode'
-    'vscode-powershell'
-    'googlechrome'
-    'git'
-  )
-}
-
-Write-Host "Installing with choco: $ChocolateyPackages"
-
-choco install $ChocolateyPackages --yes --no-progress --stop-on-first-failure
-if ($LastExitCode -ne 0) {
-  throw "Installation with choco failed."
-}
-
 $PowerShellModules = @(
   @{ Name = 'PSFramework' }
   @{ Name = 'PSModuleDevelopment' ; RequiredVersion = '2.2.7.90' }
@@ -32,8 +16,36 @@ $PowerShellModules = @(
   @{ Name = 'PSDscResources' ; RequiredVersion = '2.12.0.0' }
   @{ Name = 'AccessControlDsc' ; RequiredVersion = '1.4.0.0' }
 )
+
+if ($ENV:CI -ne 'True') {
+  $ChocolateyPackages += @(
+    'vscode'
+    'vscode-powershell'
+    'googlechrome'
+    'git'
+    'poshgit'
+  )
+  $PowerShellModules += @(
+    @{ Name = 'RubyInstaller' }
+  )
+}
+
+Write-Host "Installing with choco: $ChocolateyPackages"
+
+choco install $ChocolateyPackages --yes --no-progress --stop-on-first-failure
+if ($LastExitCode -ne 0) {
+  throw "Installation with choco failed."
+}
+
 Write-Host "Installing $($PowerShellModules.Count) modules with Install-Module"
 Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
 ForEach ($Module in $PowerShellModules) {
   Install-Module @Module -Force
+}
+
+if ($ENV:CI -ne 'True') {
+  Import-Module 'RubyInstaller'
+  # Non-functional, pending an investigation and PR to RubyInstaller?
+  # For now you need to run it interactively
+  # Install-Ruby -RubyVersions '2.5.1' -Verbose
 }

--- a/extras/profile.ps1
+++ b/extras/profile.ps1
@@ -1,0 +1,18 @@
+Function New-LocalGemfile {
+  Param (
+    [string]$Path
+  )
+  $Gems = @"
+gem 'fuubar'
+gem 'pry-byebug'
+gem 'pry-stack_explorer'
+"@
+  if ([string]::IsNullOrEmpty($Path)) {
+    $Path = Join-Path -Path (Get-Location) -ChildPath 'gemfile.local'
+  }
+  [IO.File]::WriteAllLines($Path, $Gems)
+}
+
+Import-Module C:\ProgramData\chocolatey\helpers\chocolateyProfile.psm1
+Update-SessionEnvironment
+Import-Module C:\tools\poshgit\*posh-git*\src\posh-git.psd1


### PR DESCRIPTION
This commit updates the vagrant provisioning to prepare for the
installation of rubies via uru/rubyinstaller and improves the
dev ux in the vagrant box by adding posh-git and a helper function
for creating a new Gemfile.local with the pry gems.

This should enable pry debugging during generated module testing.

NB: The automatic ruby installer is non-functional, users will need
to run Install-Ruby interactively when first logging into the new
Vagrant box.

- Resolves #94