### PR TITLE
(maint) - Install Ruby Installer Module

### DIFF
--- a/extras/install.ps1
+++ b/extras/install.ps1
@@ -31,6 +31,7 @@ $PowerShellModules = @(
   @{ Name = 'xPSDesiredStateConfiguration' }
   @{ Name = 'PSDscResources' ; RequiredVersion = '2.12.0.0' }
   @{ Name = 'AccessControlDsc' ; RequiredVersion = '1.4.0.0' }
+  @{ Name = 'RubyInstaller' }
 )
 Write-Host "Installing $($PowerShellModules.Count) modules with Install-Module"
 Set-PSRepository -Name PSGallery -InstallationPolicy Trusted


### PR DESCRIPTION
Adding the RubyInstaller Module from The Powershell Gallery.
This will make managing ruby easier on Windows when developing. 

This has been tested on the Vagrant image and I can confirm that the Ruby Installer has been installed alongside the additional modules.

