### PR TITLE
(MAINT) Only write attributes if parameter is not null

### DIFF
--- a/src/internal/functions/Get-TypeParameterContent.ps1
+++ b/src/internal/functions/Get-TypeParameterContent.ps1
@@ -23,7 +23,8 @@ Function Get-TypeParameterContent {
   )
 
   ForEach ($Parameter in $ParameterInfo) {
-    New-Object -TypeName System.String @"
+    if (![string]::IsNullOrEmpty($Parameter.name)) {
+      New-Object -TypeName System.String @"
     dsc_$($Parameter.name): {
       type: $(ConvertTo-PuppetRubyString -String ($Parameter.Type -split "`n" -join "`n            ")),
 $(
@@ -52,5 +53,6 @@ $(
       mof_is_embedded: $($Parameter.mof_is_embedded),
     },
 "@
+    }
   }
 }


### PR DESCRIPTION
Prior to this commit the Get-TypeContent function would sometimes pass
a null object to Get-TypeParameterContent which would then write a non-
functional attribute definition, breaking the type.

I was not able to discover how this was happening, but this small patch
seemed like a sensible enough guard given prioritization.