### PR TITLE
(GH-80) Typify read only properties

### DIFF
--- a/src/internal/functions/Get-DscResourceParameterInfoByCimClass.ps1
+++ b/src/internal/functions/Get-DscResourceParameterInfoByCimClass.ps1
@@ -86,10 +86,7 @@ Function Get-DscResourceParameterInfoByCimClass {
     # - https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/DscSupport/CimDSCParser.cs#L1203
     $PropertiesToDiscard = @('ConfigurationName', 'DependsOn', 'ModuleName', 'ModuleVersion', 'ResourceID', 'SourceInfo')
     $DscResourceCimClassProperties = Get-CimClassPropertiesList -ClassName $DscResource.ResourceType |
-      Where-Object {
-        $_.Name -notin $PropertiesToDiscard -and
-        -not $_.Flags.HasFlag([Microsoft.Management.Infrastructure.CimFlags]::ReadOnly)
-      }
+      Where-Object { $_.Name -notin $PropertiesToDiscard }
 
     $DscResourceMetadata = @{}
 
@@ -105,6 +102,7 @@ Function Get-DscResourceParameterInfoByCimClass {
         Help = $Property.Qualifiers['Description'].Value
         is_parameter      = Test-DscResourcePropertyParameterStatus -Property $Property
         is_namevar        = ($Property.Flags -Match 'Key').ToString().ToLowerInvariant()
+        is_read_only      = $Property.Flags.HasFlag([Microsoft.Management.Infrastructure.CimFlags]::ReadOnly)
         mandatory_for_get = $IsMandatory.ToString().ToLowerInvariant()
         mandatory_for_set = $IsMandatory.ToString().ToLowerInvariant()
         mof_is_embedded   = 'false'

--- a/src/internal/functions/Get-TypeParameterContent.ps1
+++ b/src/internal/functions/Get-TypeParameterContent.ps1
@@ -40,6 +40,7 @@ $(
   $Behaviours = @()
   If ($Parameter.is_namevar -eq 'true') { $Behaviours += ':namevar' }
   If ($Parameter.is_parameter -eq $true) { $Behaviours += ':parameter' }
+  If ($Parameter.is_read_only -eq $true) { $Behaviours += ':read_only' }
   If ($Behaviours.count -eq 1) {
     "      behaviour: $($Behaviours[0]),"
   } ElseIf ($Behaviours.count -gt 1) {


### PR DESCRIPTION
Prior to this commit the type generator ignored read-only DSC Resource properties. This commit ensures that if the read-only flag is set on a DSC Resource property it is included in the generated type with the appropriate Resource API behaviour.

- Resolves #80