### PR TITLE
(GH-85) Make puppetizing prerelease modules switchable

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -21,6 +21,8 @@
       The name of the Puppet module author; if not specified, will default to your PDK configuration's author.
     .PARAMETER OutputDirectory
       The folder in which to build the Puppet module. Defaults to a folder called import in the current location.
+    .PARAMETER AllowPrerelease
+      Allows you to Puppetize a module marked as a prerelease.
     .PARAMETER PassThru
       If specified, the function returns the path to the root folder of the Puppetized module on the filesystem.
     .PARAMETER Confirm
@@ -41,6 +43,7 @@
     [string]$PuppetModuleName,
     [string]$PuppetModuleAuthor,
     [string]$OutputDirectory,
+    [switch]$AllowPrerelease,
     [switch]$PassThru
   )
 

--- a/src/functions/New-PuppetDscModule.ps1
+++ b/src/functions/New-PuppetDscModule.ps1
@@ -22,6 +22,8 @@ Function New-PuppetDscModule {
       The name of the Puppet module author; if not specified, will default to your PDK configuration's author.
     .PARAMETER OutputDirectory
       The folder in which to build the Puppet module. Defaults to a folder called import in the current location.
+    .PARAMETER AllowPrerelease
+      Allows you to Puppetize a module marked as a prerelease.
     .PARAMETER PassThru
       If specified, the function returns the path to the root folder of the Puppetized module on the filesystem.
     .PARAMETER Confirm
@@ -45,6 +47,7 @@ Function New-PuppetDscModule {
     [string]$PuppetModuleName,
     [string]$PuppetModuleAuthor,
     [string]$OutputDirectory,
+    [switch]$AllowPrerelease,
     [switch]$PassThru,
     [string]$Repository
   )
@@ -97,7 +100,7 @@ Function New-PuppetDscModule {
 
         # Vendor the PowerShell module and all of its dependencies
         Write-PSFMessage -Message 'Vendoring the DSC Resources'
-        Add-DscResourceModule -Name $PowerShellModuleName -Path $VendoredDscResourcesDirectory -RequiredVersion $PowerShellModuleVersion -Repository $Repository
+        Add-DscResourceModule -Name $PowerShellModuleName -Path $VendoredDscResourcesDirectory -RequiredVersion $PowerShellModuleVersion -Repository $Repository -AllowPrerelease:$AllowPrerelease
 
         # Update the Puppet module metadata
         Write-PSFMessage -Message 'Updating the Puppet Module metadata'

--- a/src/internal/functions/Add-DscResourceModule.ps1
+++ b/src/internal/functions/Add-DscResourceModule.ps1
@@ -21,6 +21,9 @@ function Add-DscResourceModule {
   .PARAMETER Repository
     Specifies a PSRepository.
 
+  .PARAMETER AllowPrerelease
+    Allows you to Puppetize a module marked as a prerelease.
+
   .EXAMPLE
     Add-DscResourceModule -TargetDir ./tmp -Name PowerShellGet -Version 2.2.3 -Repository PSGallery
 
@@ -32,7 +35,8 @@ function Add-DscResourceModule {
     $Name,
     $Path,
     $RequiredVersion,
-    $Repository
+    $Repository,
+    [switch]$AllowPrerelease
   )
 
   Begin { }
@@ -46,7 +50,7 @@ function Add-DscResourceModule {
       if (-not(Test-Path $PathTmp)) {
         $null = New-Item -Path $PathTmp -Force -ItemType 'Directory'
       }
-      Save-Module -Name $Name -Path $PathTmp -RequiredVersion $RequiredVersion -Repository $Repository -AllowPrerelease
+      Save-Module -Name $Name -Path $PathTmp -RequiredVersion $RequiredVersion -Repository $Repository -AllowPrerelease:$AllowPrerelease
       ForEach ($ModuleFolder in (Get-ChildItem $PathTmp)) {
         Move-Item -Path (Get-ChildItem $ModuleFolder.FullName).FullName -Destination "$Path/$($ModuleFolder.Name)"
       }

--- a/src/tests/functions/Add-DscResourceModule.Tests.ps1
+++ b/src/tests/functions/Add-DscResourceModule.Tests.ps1
@@ -1,6 +1,6 @@
 Describe 'Vendoring a DSC module' {
   InModuleScope puppet.dsc {
-    Context 'With all params specified' {
+    Context 'Without AllowPrerelease specified' {
       Mock New-Item -Verifiable
       Mock Save-Module -Verifiable
       Mock Test-Path { $false } -ParameterFilter { $path -eq 'TestDrive:\target\' }
@@ -11,7 +11,7 @@ Describe 'Vendoring a DSC module' {
 
       Add-DscResourceModule -Name SomeDSCModule -Path 'TestDrive:\target\' -RequiredVersion '1.0.0' -Repository 'PSGallery'
 
-      It 'downloads the latest version of the module' {
+      It 'downloads the latest stable version of the module' {
         Assert-VerifiableMock
         Assert-MockCalled New-Item -Times 1 -ParameterFilter { ($path -eq 'TestDrive:\target\') -and ($ItemType -eq 'Directory') }
         Assert-MockCalled New-Item -Times 1 -ParameterFilter { ($path -eq 'TestDrive:\target_tmp') -and ($ItemType -eq 'Directory') }
@@ -20,6 +20,31 @@ Describe 'Vendoring a DSC module' {
             -and ($path -eq 'TestDrive:\target_tmp') `
             -and ($RequiredVersion -eq '1.0.0') `
             -and ($Repository -eq 'PSGallery')
+        }
+        Assert-MockCalled Remove-Item -Times 1 -ParameterFilter { $path -eq 'TestDrive:\target_tmp' }
+      }
+    }
+    Context 'With AllowPrerelease specified' {
+      Mock New-Item -Verifiable
+      Mock Save-Module -Verifiable
+      Mock Test-Path { $false } -ParameterFilter { $path -eq 'TestDrive:\target\' }
+      Mock Test-Path { $false } -ParameterFilter { $path -eq 'TestDrive:\target_tmp' }
+      Mock Get-ChildItem
+      Mock Move-Item
+      Mock Remove-Item
+
+      Add-DscResourceModule -Name SomeDSCModule -Path 'TestDrive:\target\' -RequiredVersion '1.0.0' -Repository 'PSGallery' -AllowPrerelease
+
+      It 'downloads the latest stable version of the module' {
+        Assert-VerifiableMock
+        Assert-MockCalled New-Item -Times 1 -ParameterFilter { ($path -eq 'TestDrive:\target\') -and ($ItemType -eq 'Directory') }
+        Assert-MockCalled New-Item -Times 1 -ParameterFilter { ($path -eq 'TestDrive:\target_tmp') -and ($ItemType -eq 'Directory') }
+        Assert-MockCalled Save-Module -Times 1 -Debug -ParameterFilter {
+          ($Name -eq 'SomeDSCModule') `
+            -and ($path -eq 'TestDrive:\target_tmp') `
+            -and ($RequiredVersion -eq '1.0.0') `
+            -and ($Repository -eq 'PSGallery') `
+            -and ($AllowPrerelease -eq $true)
         }
         Assert-MockCalled Remove-Item -Times 1 -ParameterFilter { $path -eq 'TestDrive:\target_tmp' }
       }


### PR DESCRIPTION
Prior to this commit the `AllowPrerelease` flag was always passed to `Save-Module` in the `Add-DscResourcModule` function. This meant that if no version was specifically passed during a call to `New-PuppetDscModule` or `Add-DscResourceModule` they would always default to the latest version on the Gallery *including* pre- release versions which is unexpected UX.

This PR ensures that prerelease versions are only puppetized if the `AllowPrerelease` switch is specified and adds that parameter to both functions.

- Resolves #85 