### PR TITLE
(MAINT) Update version pins for metadata.json

### DIFF
--- a/src/internal/functions/Update-PuppetModuleMetadata.ps1
+++ b/src/internal/functions/Update-PuppetModuleMetadata.ps1
@@ -73,7 +73,7 @@ function Update-PuppetModuleMetadata {
     $PuppetMetadata.dependencies = @(
       @{
         name = 'puppetlabs/pwshlib'
-        version_requirement = '>= 0.5.1 < 2.0.0'
+        version_requirement = '>= 0.6.1 < 2.0.0'
       }
     )
     # Update the operating sytem to only support windows *for now*.
@@ -89,7 +89,7 @@ function Update-PuppetModuleMetadata {
       }
     )
     # Clarify Puppet lower bound
-    $PuppetMetadata.requirements[0].version_requirement = '>= 6.0.0 < 7.0.0'
+    $PuppetMetadata.requirements[0].version_requirement = '>= 6.0.0 < 8.0.0'
     # Tag the module as coming from the builder so that it becomes searchable on the Forge.
     $PuppetMetadata | Add-Member -MemberType NoteProperty -Name tags -Value @(
       'windows',

--- a/src/tests/functions/Update-PuppetModuleMetadata.Tests.ps1
+++ b/src/tests/functions/Update-PuppetModuleMetadata.Tests.ps1
@@ -74,7 +74,7 @@ Describe 'Update-PuppetModuleMetadata' {
         }
         It 'Updates the dependencies' {
           $Result.dependencies[0].Name | Should -Be 'puppetlabs/pwshlib'
-          $Result.dependencies[0].version_requirement | Should -Be '>= 0.5.1 < 2.0.0'
+          $Result.dependencies[0].version_requirement | Should -Be '>= 0.6.1 < 2.0.0'
         }
         It 'Updates the supported operating system list' {
           $Result.operatingsystem_support[0].operatingsystem | Should -Be 'windows'
@@ -84,7 +84,7 @@ Describe 'Update-PuppetModuleMetadata' {
           $Result.operatingsystem_support[0].operatingsystemrelease | Should -Contain '2019'
         }
         It 'Updates the Puppet lower bound' {
-          $Result.requirements[0].version_requirement | Should -Be '>= 6.0.0 < 7.0.0'
+          $Result.requirements[0].version_requirement | Should -Be '>= 6.0.0 < 8.0.0'
         }
         It 'Sets the appropriate tags' {
           $Result.tags[0] | Should -Be 'windows'


### PR DESCRIPTION
This commit raises the lower bound for the pwshlib dependency to 0.6.1 and the upper bound for Puppet to 8.0.0 in accordance with changes in the provider and the stable release of Puppet 7 respectively.