### PR TITLE
(MAINT) Add Util Functions

### DIFF
--- a/extras/install.ps1
+++ b/extras/install.ps1
@@ -24,6 +24,7 @@ if ($ENV:CI -ne 'True') {
     'googlechrome'
     'git'
     'poshgit'
+    'curl'
   )
   $PowerShellModules += @(
     @{ Name = 'RubyInstaller' }

--- a/extras/util.ps1
+++ b/extras/util.ps1
@@ -1,0 +1,313 @@
+Function ConvertTo-VersionBuild {
+  [CmdletBinding()]
+  param (
+    [Parameter()]
+    [String[]]
+    $Version
+  )
+
+  Begin { }
+  Process {
+    $Version | Sort-Object -Descending | ForEach-Object -Process {
+      [pscustomobject]@{
+        Version = $_.substring(0, ($_.length - 2))
+        Build   = [int]([string]$_[-1])
+      }
+    }
+  }
+  End { }
+}
+
+Function Get-LatestBuild {
+  [CmdletBinding()]
+  param (
+    [Parameter()]
+    [String[]]
+    $Version
+  )
+  Begin { }
+  Process {
+    $VersionAndBuild = ConvertTo-VersionBuild -Version $Version
+    $VersionAndBuild.version |
+    Select-Object -Unique |
+    ForEach-Object -Process {
+      $VersionAndBuild |
+      Where-Object -Property Version -eq $_ |
+      Sort-Object -Property Build -Descending |
+      Select-Object -First 1
+    }
+  }
+  End { }
+}
+
+Function ConvertFrom-VersionBuild {
+  [CmdletBinding()]
+  param (
+    [Parameter(ValueFromPipeline = $true)]
+    [object[]]
+    $VersionBuild
+  )
+
+  Begin { }
+  Process {
+    $VersionBuild | ForEach-Object -Process {
+      "$($_.Version)-$($_.Build)"
+    }
+  }
+  End { }
+}
+
+Function Get-ForgeModuleInfo {
+  [CmdletBinding()]
+  param (
+    [Parameter()]
+    [string[]]
+    $Name
+  )
+
+  Begin {
+    $UriBase = 'https://forgeapi.puppet.com/v3/modules/dsc-'
+    $ModuleSearchParameters = @{
+      Method          = 'Get'
+      UseBasicParsing = $True
+      Headers         = @{
+        Authotization = "Bearer $ENV:FORGE_TOKEN"
+      }
+    }
+  }
+  Process {
+    foreach ($Module in $Name) {
+      $ModuleSearchParameters.Uri = $UriBase + (Get-PuppetizedModuleName $Module)
+      $Result = Invoke-RestMethod @ModuleSearchParameters
+      [PSCustomObject]@{
+        Name                 = $Result.name
+        Releases             = $Result.releases.version
+        PowerShellModuleInfo = $Result.current_release.metadata.dsc_module_metadata
+      }
+    }
+  }
+  End { }
+}
+
+Function Get-ForgeDscModules {
+  [CmdletBinding()]
+  param (
+    [Parameter()]
+    [object[]]
+    $Name
+  )
+
+  Begin {
+    $PaginationBump = 5
+    $ForgeSearchParameters = @{
+      Method          = 'Get'
+      UseBasicParsing = $True
+      Uri             = "https://forgeapi.puppet.com/v3/modules"
+      Headers         = @{
+        Authotization = "Bearer $ENV:FORGE_TOKEN"
+      }
+      Body            = @{
+        owner  = 'dsc'
+        limit  = $PaginationBump
+        offset = 0
+      }
+    }
+    $Results = [System.Collections.ArrayList]::new()
+  }
+
+  Process {
+    do {
+      $Response = Invoke-RestMethod @ForgeSearchParameters
+      ForEach ($Result in $Response.results) {
+        $null = $Results.Add([PSCustomObject]@{
+            Name                 = $Result.name
+            Releases             = $Result.releases.version
+            PowerShellModuleInfo = $Result.current_release.metadata.dsc_module_metadata
+          })
+      }
+      $ForgeSearchParameters.body.offset += $PaginationBump
+    } until ($null -eq $Response.Pagination.Next)
+    $Results
+  }
+  End { }
+}
+
+Function Update-ForgeDscModule {
+  [CmdletBinding()]
+  param (
+    [Parameter()]
+    [string[]]$Name
+  )
+
+  Begin { }
+
+  Process {
+    If ($null -eq $Name) {
+      $ModulesToRebuild = Get-ForgeDscModules
+    }
+    Else {
+      $ModulesToRebuild = Get-ForgeModuleInfo -Name $Name
+    }
+    foreach ($Module in $ModulesToRebuild) {
+      foreach ($VersionAndBuild in (Get-LatestBuild $Module.Releases)) {
+        $OutputFolder = "$(Get-Location)/import/$($Module.Name)"
+        If (Test-Path $OutputFolder) {
+          Remove-Item $OutputFolder -Force -Recurse
+        }
+        $PuppetizeParameters = @{
+          PuppetModuleAuthor      = 'dsc'
+          PowerShellModuleName    = [string]$Module.PowerShellModuleInfo.Name
+          PowerShellModuleVersion = [string]$VersionAndBuild.Version -replace '-', '.'
+        }
+        Write-Host "Puppetizing with: $($PuppetizeParameters | Out-String)"
+        New-PuppetDscModule @PuppetizeParameters
+        $VersionAndBuild.Build += 1
+        $PublishCommand = @(
+          'pdk'
+          'release'
+          "--forge-token=$ENV:FORGE_TOKEN"
+          "--version=$($VersionAndBuild | ConvertFrom-VersionBuild)"
+          '--skip-changelog'
+          '--skip-validation'
+          '--skip-documentation'
+          '--skip-dependency'
+          '--force'
+        ) -Join ' '
+        Write-Host "Executing: $PublishCommand"
+        Invoke-PdkCommand -Path $OutputFolder -Command $PublishCommand -SuccessFilterScript { $_ -match "Publish to Forge was successful" }
+        Write-Host "Published $($Module.Name) at $($VersionAndBuild | ConvertFrom-VersionBuild)"
+      }
+    }
+  }
+
+  End { }
+}
+
+Function Get-PowerShellDscModule {
+  [CmdletBinding()]
+  param (
+    [Parameter()]
+    [string[]]
+    $Name
+  )
+
+  Begin { }
+  Process {
+    If ($null -eq $Name) {
+      $Name = Find-Module -DscResource * -Name * |
+      Select-Object -ExpandProperty Name
+    }
+
+    ForEach ($NameToSearch in $Name) {
+      $Response = Find-Module -DscResource * -Name $NameToSearch -AllVersions
+      [PSCustomObject]@{
+        Name     = $NameToSearch
+        Releases = $Response.Version
+      }
+    }
+  }
+  End { }
+}
+
+Function ConvertTo-StandardizedVersionString {
+  [CmdletBinding()]
+  param (
+    [Parameter(ValueFromPipeline = $true)]
+    [version[]]
+    $Version
+  )
+  Begin { }
+  Process {
+    ForEach ($VersionToProcess in $Version) {
+      $StandardizedVersion = [PSCustomObject]@{
+        Major    = $VersionToProcess.Major
+        Minor    = $VersionToProcess.Minor
+        Build    = $VersionToProcess.Build
+        Revision = $VersionToProcess.Revision
+      }
+      if ($StandardizedVersion.Minor -eq -1) {
+        $StandardizedVersion.Minor = 0
+      }
+      if ($StandardizedVersion.Major -eq -1) {
+        $StandardizedVersion.Major = 0
+      }
+      if ($StandardizedVersion.Build -eq -1) {
+        $StandardizedVersion.Build = 0
+      }
+      if ($StandardizedVersion.Revision -eq -1) {
+        $StandardizedVersion.Revision = 0
+      }
+      "$($StandardizedVersion.Major).$($StandardizedVersion.Minor).$($StandardizedVersion.Build).$($StandardizedVersion.Revision)"
+    }
+  }
+  End { }
+}
+
+Function Get-UnreleasedDscModuleVersion {
+  [CmdletBinding()]
+  param (
+    [Parameter()]
+    [string[]]
+    $Name
+  )
+
+  Begin { }
+  Process {
+    $GalleryModuleInfo = Get-PowerShellDscModule -Name $Name
+    ForEach ($Module in $GalleryModuleInfo) {
+      $ForgeModuleInfo = Get-ForgeModuleInfo -Name (Get-PuppetizedModuleName -Name $Module.Name)
+      $VersionsReleasedToForge = Get-LatestBuild $ForgeModuleInfo.Releases |
+        Select-Object -ExpandProperty Version |
+        ForEach-Object -Process { $_ -replace '-', '.' }
+      $ModuleVersions = ConvertTo-StandardizedVersionString -Version $Module.Releases
+      $VersionsToRelease = $ModuleVersions | Where-Object -FilterScript { $_ -notin $VersionsReleasedToForge }
+      [PSCustomObject]@{
+        Name = $Module.Name
+        Versions = $VersionsToRelease
+      }
+    }
+  }
+  End { }
+}
+
+Function Publish-NewDscModuleVersion {
+  [CmdletBinding()]
+  param (
+      [Parameter()]
+      [string[]]
+      $Name
+  )
+  Begin {}
+  Process {
+    $ModuleInformation = Get-UnreleasedDscModuleVersion -Name $Name
+    ForEach ($Module in $ModuleInformation) {
+      $OutputFolder = "$(Get-Location)/import/$($Module.Name)"
+      ForEach ($Version in $Module.Versions) {
+        If (Test-Path $OutputFolder) {
+          Remove-Item $OutputFolder -Force -Recurse
+        }
+        $PuppetizeParameters = @{
+          PuppetModuleAuthor      = 'dsc'
+          PowerShellModuleName    = $Module.Name
+          PowerShellModuleVersion = $Version
+        }
+        Write-Host "Puppetizing with: $($PuppetizeParameters | Out-String)"
+        New-PuppetDscModule @PuppetizeParameters
+        $PublishCommand = @(
+          'pdk'
+          'release'
+          "--forge-token=$ENV:FORGE_TOKEN"
+          '--skip-changelog'
+          '--skip-validation'
+          '--skip-documentation'
+          '--skip-dependency'
+          '--force'
+        ) -Join ' '
+        Write-Host "Executing: $PublishCommand"
+        Invoke-PdkCommand -Path $OutputFolder -Command $PublishCommand -SuccessFilterScript { $_ -match "Publish to Forge was successful" }
+        Write-Host "Published $($Module.Name) at $Version"
+      }
+    }
+  }
+  End {}
+}

--- a/publish.ps1
+++ b/publish.ps1
@@ -37,7 +37,7 @@ Process {
 
     # Convert and write documentation
     Import-Module "$BuildFolder\Puppet.Dsc.psd1" -Force
-    New-MarkdownHelp -Module 'Puppet.Dsc' -OutputFolder $MarkdownDocsFolder
+    New-MarkdownHelp -Module 'Puppet.Dsc' -OutputFolder $MarkdownDocsFolder -Force
     New-ExternalHelp -Path $MarkdownDocsFolder -OutputPath "$BuildFolder\en-us\"
 
     # Publish the module and tag if desired

--- a/src/internal/functions/Get-PuppetModuleVersion.ps1
+++ b/src/internal/functions/Get-PuppetModuleVersion.ps1
@@ -29,9 +29,15 @@ Function Get-PuppetModuleVersion {
     [version]$Version,
     [int]$BuildNumber = 0
   )
-  If ($Version.Revision -gt 0) {
-    "$($Version.Major).$($Version.Minor).$($Version.Build)-$($Version.Revision)-$BuildNumber"
-  } Else {
-    "$($Version.Major).$($Version.Minor).$($Version.Build)-0-$BuildNumber"
+  $PuppetVersion = [PSCustomObject]@{
+    Major    = $Version.Major
+    Minor    = $Version.Minor
+    Build    = $Version.Build
+    Revision = $Version.Revision
   }
+  If ($PuppetVersion.Minor -lt 0) { $PuppetVersion.Minor = 0 }
+  If ($PuppetVersion.Major -lt 0) { $PuppetVersion.Major = 0 }
+  If ($PuppetVersion.Build -lt 0) { $PuppetVersion.Build = 0 }
+  If ($PuppetVersion.Revision -lt 0) { $PuppetVersion.Revision = 0 }
+  "$($PuppetVersion.Major).$($PuppetVersion.Minor).$($PuppetVersion.Build)-$($PuppetVersion.Revision)-$BuildNumber"
 }


### PR DESCRIPTION
Add the following functions to a dot-sourcable script in the extras folder:

- `ConvertTo-VersionBuild`: Break a DSC Puppet version into the four-section version and build for easy incrementing and checking.
- `Get-LatestBuild`: Given a list of DSC Puppet versions, return only the latest build of each unique version to enable incrementing and rebuilding.
- `ConvertFrom-VersionBuild`: Turn a given VersionBuild object back into a DSC Puppet version string like '1.2.3-4-1'
- `Get-ForgeModuleInfo`: Return the name, list of releases, and PowerShell module metadata back from a given DSC module on the forge
- `Get-ForgeDscModules`: Retrieve all of the DSC modules on the forge, including their name, list of releases, and PowerShell module metadata
- `Update-ForgeDscModule`: Update one or more (default: all) DSC modules on the forge, rebuilding them and publishing with the Puppet build version incremented by one.
- `Get-PowerShellDscModule`: Search the Gallery for one or more (default: all) PowerShell modules with DSC Resources, return their name and all releases.
- `ConvertTo-StandardizedVersionString`: Given a version string, convert it into a string like '1.2.3.4', including for version components which were unset; without this, the versions do not write all four numbers if the version is "short", ie '1.2' instead of '1.2.0.0'
- `Get-UnreleasedDscModuleVersion`: Retrieve all of the releases on the gallery and the forge for a particular module, return the module name and all versions which have been released to the gallery but not the forge.
- `Publish-NewDscModuleVersion`: Publish to the forge all versions of a Puppetized PowerShell DSC module which exist on the gallery but not the forge