### PR TITLE
(GH-75) - PowerShell module dependencies are installable side by side

### DIFF
--- a/src/functions/New-PuppetDscModule.ps1
+++ b/src/functions/New-PuppetDscModule.ps1
@@ -73,7 +73,7 @@ Function New-PuppetDscModule {
     $OutputDirectory = New-Item -Path $OutputDirectory -ItemType "directory" -Force
 
     $PuppetModuleRootFolderDirectory = Join-Path -Path $OutputDirectory                 -ChildPath $PuppetModuleName
-    $VendoredDscResourcesDirectory   = Join-Path -Path $OutputDirectory                 -ChildPath "$PuppetModuleName/lib/puppet_x/dsc_resources"
+    $VendoredDscResourcesDirectory   = Join-Path -Path $OutputDirectory                 -ChildPath "$PuppetModuleName/lib/puppet_x/$PuppetModuleName/dsc_resources"
     $PuppetModuleTypeDirectory       = Join-Path -Path $PuppetModuleRootFolderDirectory -ChildPath 'lib/puppet/type'
     $PuppetModuleProviderDirectory   = Join-Path -Path $PuppetModuleRootFolderDirectory -ChildPath 'lib/puppet/provider'
     $InitialPSModulePath          = $Env:PSModulePath


### PR DESCRIPTION
Following this change and building 2 new DSC modules I can confirm they are now deposited in `lib/puppet_x/<module_name>/dsc_resources` instead of `lib/puppet_x/dsc_resources`.

Resolves #115 #