### PR TITLE
(GH-111) Add PowerShellGet as module dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Explicit dependency on PowerShellGet `2.2.3+` ([#111](https://github.com/puppetlabs/Puppet.Dsc/pull/111))
+
 ## [0.3.0] - 2020-12-14
 
 ### Added

--- a/src/puppet.dsc.psd1
+++ b/src/puppet.dsc.psd1
@@ -30,6 +30,7 @@
     'PSDesiredStateConfiguration'
     'PSDscResources'
     'powershell-yaml'
+    @{ ModuleName = 'PowerShellGet'; ModuleVersion = '2.2.3' }
   )
 
   # Assemblies that must be loaded prior to importing this module


### PR DESCRIPTION
Prior to this commit some users with old versions of PowerShellGet and
PackageManagement would try using the AllowPreRelease switch and get an
error indicating that switch was not available.

This commit adds a modern version of PowerShellGet as a dependency which
itself has a dependency on PackageManagement.

- Fixes #111