### PR TITLE
(GH-75) Update pwshlib pin in generated module metadata

### DIFF
--- a/src/internal/functions/Update-PuppetModuleMetadata.ps1
+++ b/src/internal/functions/Update-PuppetModuleMetadata.ps1
@@ -78,7 +78,7 @@ function Update-PuppetModuleMetadata {
     $PuppetMetadata.dependencies = @(
       @{
         name = 'puppetlabs/pwshlib'
-        version_requirement = '>= 0.6.1 < 2.0.0'
+        version_requirement = '>= 0.7.0 < 2.0.0'
       }
     )
     # Update the operating sytem to only support windows *for now*.

--- a/src/tests/functions/Update-PuppetModuleMetadata.Tests.ps1
+++ b/src/tests/functions/Update-PuppetModuleMetadata.Tests.ps1
@@ -76,7 +76,7 @@ Describe 'Update-PuppetModuleMetadata' {
         }
         It 'Updates the dependencies' {
           $Result.dependencies[0].Name | Should -Be 'puppetlabs/pwshlib'
-          $Result.dependencies[0].version_requirement | Should -Be '>= 0.6.1 < 2.0.0'
+          $Result.dependencies[0].version_requirement | Should -Be '>= 0.7.0 < 2.0.0'
         }
         It 'Updates the supported operating system list' {
           $Result.operatingsystem_support[0].operatingsystem | Should -Be 'windows'


### PR DESCRIPTION
The minimum compatible version of pwshlib must be raised to 0.7.0
to take advantage of the updated logic to work with the new vendored
module paths from #75.