### PR TITLE
(MAINT) Fix metadata summary entry definition

### DIFF
--- a/src/internal/functions/Update-PuppetModuleMetadata.ps1
+++ b/src/internal/functions/Update-PuppetModuleMetadata.ps1
@@ -43,8 +43,8 @@ function Update-PuppetModuleMetadata {
       $PuppetMetadata.author = $PuppetModuleAuthor
     }
     $PuppetMetadata.version = Get-PuppetModuleVersion -Version $PowerShellMetadata.ModuleVersion
-    $summary = $PowerShellMetadata.Description -Replace "(`r`n|`n)", '`n'
-    $summary = $PowerShellMetadata.Description -Replace '"', '\"'
+    $summary = ($PowerShellMetadata.Description -split "(`r`n|`n)")[0]
+    $summary = $summary -Replace '"', '\"'
     # summary needs to be 144 chars or less (see https://github.com/voxpupuli/metadata-json-lint/blob/5ab67f9404ee65da0efd84a597b2ee86152d2659/lib/metadata-json-lint/schema.rb#L99 )
     if ($summary.length -gt 144) {
       $summary = $summary.substring(0, 144 - 3) + "..."


### PR DESCRIPTION
Prior to this commit the Summary string in the metadata would erroneously include newlines. This commit obviates that error.