### PR TITLE
(MAINT) Add CertReq parameters to hard-coded list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `KeyUsage` and `OID` to the list of DSC Resource properties which should be treated as parameters in Puppet ([#111](https://github.com/puppetlabs/Puppet.Dsc/pull/111))
+
 ## [0.4.0] - 2021-01-27
 
 ### Added
 
-- Explicit dependency on PowerShellGet `2.2.3+` ([#111](https://github.com/puppetlabs/Puppet.Dsc/pull/111))
+- Explicit dependency on PowerShellGet `2.2.3+` ([#124](https://github.com/puppetlabs/Puppet.Dsc/pull/124))
 
 ### Changed
 

--- a/src/internal/functions/Test-DscResourcePropertyParameterStatus.ps1
+++ b/src/internal/functions/Test-DscResourcePropertyParameterStatus.ps1
@@ -27,6 +27,8 @@ Function Test-DscResourcePropertyParameterStatus {
   $KnownParameters = @(
     'Force'
     'JoinOU'
+    'KeyUsage'
+    'OID'
     'Purge'
     'Validate'
   )


### PR DESCRIPTION
The `OID` and `KeyUsage` properties of the `CertReq` DSC Resource cannot be returned, per the implementation details for that resources own `Get-TargetResource` function:

- https://github.com/dsccommunity/CertificateDsc/blob/main/source/DSCResources/DSC_CertReq/DSC_CertReq.psm1#L225-L226

This commit adds those two property names to the hard-coded list of DSC Resource properties which should be treated as parameters in Puppet.