### PR TITLE
(GH-113) Vendor modules not found in module repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `KeyUsage` and `OID` to the list of DSC Resource properties which should be treated as parameters in Puppet ([#111](https://github.com/puppetlabs/Puppet.Dsc/pull/111))
+- Logic for vendoring dependency modules which are not found in the specified PowerShell module repository but _are_ available on the machine the module is being Puppetized on ([#113](https://github.com/puppetlabs/Puppet.Dsc/issues/113))
 
 ## [0.4.0] - 2021-01-27
 

--- a/src/tests/functions/Add-DscResourceModule.Tests.ps1
+++ b/src/tests/functions/Add-DscResourceModule.Tests.ps1
@@ -5,6 +5,7 @@ Describe 'Vendoring a DSC module' {
       Mock Save-Module -Verifiable
       Mock Test-Path { $false } -ParameterFilter { $path -eq 'TestDrive:\target\' }
       Mock Test-Path { $false } -ParameterFilter { $path -eq 'TestDrive:\target_tmp' }
+      Mock Get-Module
       Mock Get-ChildItem
       Mock Move-Item
       Mock Remove-Item
@@ -29,6 +30,7 @@ Describe 'Vendoring a DSC module' {
       Mock Save-Module -Verifiable
       Mock Test-Path { $false } -ParameterFilter { $path -eq 'TestDrive:\target\' }
       Mock Test-Path { $false } -ParameterFilter { $path -eq 'TestDrive:\target_tmp' }
+      Mock Get-Module
       Mock Get-ChildItem
       Mock Move-Item
       Mock Remove-Item
@@ -45,6 +47,70 @@ Describe 'Vendoring a DSC module' {
             -and ($RequiredVersion -eq '1.0.0') `
             -and ($Repository -eq 'PSGallery') `
             -and ($AllowPrerelease -eq $true)
+        }
+        Assert-MockCalled Remove-Item -Times 1 -ParameterFilter { $path -eq 'TestDrive:\target_tmp' }
+      }
+    }
+    Context 'When a required module is found in the repository' {
+      Mock New-Item -Verifiable
+      Mock Save-Module -Verifiable
+      Mock Test-Path { $false } -ParameterFilter { $path -eq 'TestDrive:\target\' }
+      Mock Test-Path { $false } -ParameterFilter { $path -eq 'TestDrive:\target_tmp' }
+      Mock Test-Path { $true  } -ParameterFilter { $path -match 'foo' }
+      Mock Get-Module { @{ RequiredModules = @("foo") } } -ParameterFilter {$Name -match "SomeDscModule"}
+      Mock Get-Module
+      Mock Copy-Item
+      Mock Get-ChildItem
+      Mock Move-Item
+      Mock Remove-Item
+
+      Add-DscResourceModule -Name SomeDSCModule -Path 'TestDrive:\target\' -RequiredVersion '1.0.0' -Repository 'PSGallery'
+
+      It 'sees that the required module is vendored' {
+        Assert-VerifiableMock
+        Assert-MockCalled New-Item -Times 1 -ParameterFilter { ($path -eq 'TestDrive:\target\') -and ($ItemType -eq 'Directory') }
+        Assert-MockCalled New-Item -Times 1 -ParameterFilter { ($path -eq 'TestDrive:\target_tmp') -and ($ItemType -eq 'Directory') }
+        Assert-MockCalled Save-Module -Times 1 -Debug -ParameterFilter {
+          ($Name -eq 'SomeDSCModule') `
+            -and ($path -eq 'TestDrive:\target_tmp') `
+            -and ($RequiredVersion -eq '1.0.0') `
+            -and ($Repository -eq 'PSGallery')
+        }
+        Assert-MockCalled Copy-Item -Times 0
+        Assert-MockCalled Remove-Item -Times 1 -ParameterFilter { $path -eq 'TestDrive:\target_tmp' }
+      }
+    }
+    Context 'When a required module is not found in the repository' {
+      Mock New-Item -Verifiable
+      Mock Save-Module -Verifiable
+      Mock Test-Path { $false } -ParameterFilter { $path -eq 'TestDrive:\target\' }
+      Mock Test-Path { $false } -ParameterFilter { $path -eq 'TestDrive:\target_tmp' }
+      Mock Test-Path { $false  } -ParameterFilter { $path -match 'foo' }
+      Mock Get-Module { @{ RequiredModules = @("foo") } } -ParameterFilter {$Name -match "SomeDscModule"}
+      Mock Get-Module { @{ Path = "TestDrive:\target_tmp\foo\foo.psd1" } } -ParameterFilter {$Name -match 'foo'}
+      Mock Copy-Item
+      Mock Get-ChildItem
+      Mock Move-Item
+      Mock Remove-Item
+
+      Add-DscResourceModule -Name SomeDSCModule -Path 'TestDrive:\target\' -RequiredVersion '1.0.0' -Repository 'PSGallery'
+
+      It 'downloads the latest stable version of the module' {
+        Assert-VerifiableMock
+        Assert-MockCalled New-Item -Times 1 -ParameterFilter { ($path -eq 'TestDrive:\target\') -and ($ItemType -eq 'Directory') }
+        Assert-MockCalled New-Item -Times 1 -ParameterFilter { ($path -eq 'TestDrive:\target_tmp') -and ($ItemType -eq 'Directory') }
+        Assert-MockCalled Save-Module -Times 1 -Debug -ParameterFilter {
+          ($Name -eq 'SomeDSCModule') `
+            -and ($path -eq 'TestDrive:\target_tmp') `
+            -and ($RequiredVersion -eq '1.0.0') `
+            -and ($Repository -eq 'PSGallery')
+        }
+        Assert-MockCalled Get-Module -Times 1 -ParameterFilter { $Name -eq 'foo' }
+        Assert-MockCalled Copy-Item -Times 1 -ParameterFilter {
+          ($Path -match 'foo') `
+            -and ($Destination -eq "TestDrive:\target_tmp") `
+            -and ($Container -eq $true) `
+            -and ($Recurse -eq $true)
         }
         Assert-MockCalled Remove-Item -Times 1 -ParameterFilter { $path -eq 'TestDrive:\target_tmp' }
       }


### PR DESCRIPTION
Prior to this commit some modules, like the PrintManagementDsc module,
include dependencies in the RequiredModules key of their manifest which
cannot be found on the public gallery. This caused errors during the build
process as the ModulePath is temporarily munged.

This commit overcomes that problem by vendoring the dependencies in, even if
they cannot be found in the specified repo, so long as they are available on
the machine puppetizing the PowerShell module containing DSC Resources.

- Resolves #113