### PR TITLE
(GH-133) Throw if PSRemoting is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Ability to set generated modules fixtures to something other than the latest released version of `puppetlabs-pwshlib` on the Forge ([#93](https://github.com/puppetlabs/Puppet.Dsc/issues/93))
+- A check to `New-PuppetDscModule` which validates that PSRemoting is enabled and errors clearly if not in order to prevent unexpected execution failures later in the process ([#133](https://github.com/puppetlabs/Puppet.Dsc/issues/133))
 
 ## [0.5.0] - 2021-2-10
 

--- a/src/functions/New-PuppetDscModule.Tests.ps1
+++ b/src/functions/New-PuppetDscModule.Tests.ps1
@@ -13,6 +13,7 @@ Describe "New-PuppetDscModule" {
         Mock ConvertTo-CanonicalPuppetAuthorName {$AuthorName}
         Mock Initialize-PuppetModule {}
         Mock Write-PSFMessage {}
+        Mock Test-WSMan {}
         Mock Test-RunningElevated { return $true }
         Mock Test-SymLinkedItem   { return $false }
         Mock Add-DscResourceModule {}
@@ -405,6 +406,18 @@ Describe "New-PuppetDscModule" {
               Should -Throw -PassThru |
               Select-Object -ExpandProperty Exception |
               Should -Match "The specified output folder '.+' has a symlink in the path; CIM class parsing will not work in a symlinked folder, specify another path"
+          }
+        }
+        Context 'When running elevated and PSRemoting is disabled' {
+          BeforeAll {
+            Mock Test-WSMan { Throw 'Oops' }
+          }
+
+          It 'throws an explanatory exception' {
+            { New-PuppetDscModule -PowerShellModuleName Foo } |
+              Should -Throw -PassThru |
+              Select-Object -ExpandProperty Exception |
+              Should -Match 'PSRemoting does not appear to be enabled'
           }
         }
       }

--- a/src/functions/New-PuppetDscModule.ps1
+++ b/src/functions/New-PuppetDscModule.ps1
@@ -93,6 +93,11 @@ Function New-PuppetDscModule {
       If (Test-SymLinkedItem -Path $OutputDirectory -Recurse) {
         Stop-PsfFunction -EnableException $true -Message "The specified output folder '$OutputDirectory' has a symlink in the path; CIM class parsing will not work in a symlinked folder, specify another path"
       }
+      Try {
+        $null = Test-WSMan -ErrorAction Stop
+      } Catch {
+        Stop-PsfFunction -EnableException $true -Message "PSRemoting does not appear to be enabled; in order to parse CIM instances, the function needs to do a stubbed DSC invocation; this will fail without PSRemoting enabled. Enable PSRemoting (possibly via the Enable-PSRemoting command) before retrying. Exception:`r`n$($_.Exception | Format-List -Force * | Out-String )"
+      }
     }
   }
 


### PR DESCRIPTION
Prior to this commit, the `New-PuppetDscModule` command could fail unexpectedly if PSRemoting is not enabled; when attempting to map CIM instances the command would fail with an esoteric null error.

This commit adds an explicit check to the command which validates that PSRemoting is enabled if running as administrator and errors clearly if it is not.

- Resolves #133