### PR TITLE
(GH-153) Ensure generated readme contains module name info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ensure that the auto-generated readme of a Puppetized module contains both the PowerShell and Puppet module names ([#153](https://github.com/puppetlabs/Puppet.Dsc/issues/153))
 - Make all `Update-PuppetModuleReadme` parameters except `PuppetModuleName` mandatory and do not accept null or empty values ([#153](https://github.com/puppetlabs/Puppet.Dsc/issues/153))
+- Make the  `PowerShellModuleName` and `PuppetModuleName` parameters in `Get-Readmecontent` mandatory and do not accept null or empty values for any parameters ([#153](https://github.com/puppetlabs/Puppet.Dsc/issues/153))
+
 ## [0.5.0] - 2021-2-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Ensure that the auto-generated readme of a Puppetized module contains both the PowerShell and Puppet module names ([#153](https://github.com/puppetlabs/Puppet.Dsc/issues/153))
+- Make all `Update-PuppetModuleReadme` parameters except `PuppetModuleName` mandatory and do not accept null or empty values ([#153](https://github.com/puppetlabs/Puppet.Dsc/issues/153))
 ## [0.5.0] - 2021-2-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ability to set generated modules fixtures to something other than the latest released version of `puppetlabs-pwshlib` on the Forge ([#93](https://github.com/puppetlabs/Puppet.Dsc/issues/93))
 - A check to `New-PuppetDscModule` which validates that PSRemoting is enabled and errors clearly if not in order to prevent unexpected execution failures later in the process ([#133](https://github.com/puppetlabs/Puppet.Dsc/issues/133))
 
+### Fixed
+
+- Ensure that the auto-generated readme of a Puppetized module contains both the PowerShell and Puppet module names ([#153](https://github.com/puppetlabs/Puppet.Dsc/issues/153))
 ## [0.5.0] - 2021-2-10
 
 ### Added

--- a/src/functions/New-PuppetDscModule.Tests.ps1
+++ b/src/functions/New-PuppetDscModule.Tests.ps1
@@ -79,6 +79,8 @@ Describe "New-PuppetDscModule" {
         }
         It 'Updates the Puppet README based on the PowerShell metadata' {
           Should -Invoke Update-PuppetModuleReadme -ParameterFilter {
+            $PuppetModuleName             -match 'foo' -and
+            $PowerShellModuleName         -match 'Foo' -and
             $PuppetModuleFolderPath       -match 'import(/|\\)foo' -and
             $PowerShellModuleManifestPath -match 'import(/|\\)foo\S+(/|\\)foo(/|\\)foo.psd1'
           } -Scope Context

--- a/src/functions/New-PuppetDscModule.ps1
+++ b/src/functions/New-PuppetDscModule.ps1
@@ -136,7 +136,7 @@ Function New-PuppetDscModule {
 
         # Write the Puppet module README
         Write-PSFMessage -Message 'Writing the Puppet Module readme'
-        Update-PuppetModuleReadme -PuppetModuleFolderPath $PuppetModuleRootFolderDirectory -PowerShellModuleManifestPath $PowerShellModuleManifestPath
+        Update-PuppetModuleReadme -PuppetModuleName $PuppetModuleName -PowerShellModuleName $PowerShellModuleName -PuppetModuleFolderPath $PuppetModuleRootFolderDirectory -PowerShellModuleManifestPath $PowerShellModuleManifestPath
 
         # Write the Puppet module changelog based on PowerShell module
         Write-PSFMessage -Message 'Writing the Puppet Module changelog'

--- a/src/internal/functions/Get-ReadmeContent.Tests.ps1
+++ b/src/internal/functions/Get-ReadmeContent.Tests.ps1
@@ -47,5 +47,93 @@ Describe 'Get-ReadmeContent' {
         $Result | Should -MatchExactly "\[file an issue\]\($($Parameters.PowerShellModuleProjectUri)\)"
       }
     }
+    Context 'Parameter handling' {
+      It 'Errors if the PowerShellModuleName is not specified' {
+        $Parameters = @{
+          PowerShellModuleDescription = 'Foo and bar and baz!'
+          PowerShellModuleGalleryUri  = 'https://powershellgallery.com/Foo.Bar/1.0.0'
+          PowerShellModuleProjectUri  = 'https://github.com/Baz/Foo.Bar'
+          PowerShellModuleVersion     = '1.0.0'
+          PuppetModuleName            = 'foo_bar'
+        }
+        { Get-ReadmeContent @Parameters  } | Should -Throw "Cannot process command because of one or more missing mandatory parameters: PowerShellModuleName."
+      }
+      It 'Errors if the PuppetModuleName is not specified' {
+        $Parameters = @{
+          PowerShellModuleName        = 'Foo.Bar'
+          PowerShellModuleDescription = 'Foo and bar and baz!'
+          PowerShellModuleGalleryUri  = 'https://powershellgallery.com/Foo.Bar/1.0.0'
+          PowerShellModuleProjectUri  = 'https://github.com/Baz/Foo.Bar'
+          PowerShellModuleVersion     = '1.0.0'
+        }
+        { Get-ReadmeContent @Parameters  } | Should -Throw "Cannot process command because of one or more missing mandatory parameters: PuppetModuleName."
+      }
+      It 'Errors if the PowerShellModuleName is specified as an empty string' {
+        $Parameters = @{
+          PowerShellModuleName        = ''
+          PowerShellModuleDescription = 'Foo and bar and baz!'
+          PowerShellModuleGalleryUri  = 'https://powershellgallery.com/Foo.Bar/1.0.0'
+          PowerShellModuleProjectUri  = 'https://github.com/Baz/Foo.Bar'
+          PowerShellModuleVersion     = '1.0.0'
+          PuppetModuleName            = 'foo_bar'
+        }
+        { Get-ReadmeContent @Parameters  } | Should -Throw "Cannot validate argument on parameter 'PowerShellModuleName'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
+      }
+      It 'Errors if the PowerShellModuleDescription is specified as an empty string' {
+        $Parameters = @{
+          PowerShellModuleName        = 'Foo.Bar'
+          PowerShellModuleDescription = ''
+          PowerShellModuleGalleryUri  = 'https://powershellgallery.com/Foo.Bar/1.0.0'
+          PowerShellModuleProjectUri  = 'https://github.com/Baz/Foo.Bar'
+          PowerShellModuleVersion     = '1.0.0'
+          PuppetModuleName            = 'foo_bar'
+        }
+        { Get-ReadmeContent @Parameters  } | Should -Throw "Cannot validate argument on parameter 'PowerShellModuleDescription'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
+      }
+      It 'Errors if the PowerShellModuleGalleryUri is specified as an empty string' {
+        $Parameters = @{
+          PowerShellModuleName        = 'Foo.Bar'
+          PowerShellModuleDescription = 'Foo and bar and baz!'
+          PowerShellModuleGalleryUri  = ''
+          PowerShellModuleProjectUri  = 'https://github.com/Baz/Foo.Bar'
+          PowerShellModuleVersion     = '1.0.0'
+          PuppetModuleName            = 'foo_bar'
+        }
+        { Get-ReadmeContent @Parameters  } | Should -Throw "Cannot validate argument on parameter 'PowerShellModuleGalleryUri'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
+      }
+      It 'Errors if the PowerShellModuleProjectUri is specified as an empty string' {
+        $Parameters = @{
+          PowerShellModuleName        = 'Foo.Bar'
+          PowerShellModuleDescription = 'Foo and bar and baz!'
+          PowerShellModuleGalleryUri  = 'https://powershellgallery.com/Foo.Bar/1.0.0'
+          PowerShellModuleProjectUri  = ''
+          PowerShellModuleVersion     = '1.0.0'
+          PuppetModuleName            = 'foo_bar'
+        }
+        { Get-ReadmeContent @Parameters  } | Should -Throw "Cannot validate argument on parameter 'PowerShellModuleProjectUri'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
+      }
+      It 'Errors if the PowerShellModuleVersion is specified as an empty string' {
+        $Parameters = @{
+          PowerShellModuleName        = 'Foo.Bar'
+          PowerShellModuleDescription = 'Foo and bar and baz!'
+          PowerShellModuleGalleryUri  = 'https://powershellgallery.com/Foo.Bar/1.0.0'
+          PowerShellModuleProjectUri  = 'https://github.com/Baz/Foo.Bar'
+          PowerShellModuleVersion     = ''
+          PuppetModuleName            = 'foo_bar'
+        }
+        { Get-ReadmeContent @Parameters  } | Should -Throw "Cannot validate argument on parameter 'PowerShellModuleVersion'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
+      }
+      It 'Errors if the PuppetModuleName is specified as an empty string' {
+        $Parameters = @{
+          PowerShellModuleName        = 'Foo.Bar'
+          PowerShellModuleDescription = 'Foo and bar and baz!'
+          PowerShellModuleGalleryUri  = 'https://powershellgallery.com/Foo.Bar/1.0.0'
+          PowerShellModuleProjectUri  = 'https://github.com/Baz/Foo.Bar'
+          PowerShellModuleVersion     = '1.0.0'
+          PuppetModuleName            = ''
+        }
+        { Get-ReadmeContent @Parameters  } | Should -Throw "Cannot validate argument on parameter 'PuppetModuleName'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
+      }
+    }
   }
 }

--- a/src/internal/functions/Get-ReadmeContent.ps1
+++ b/src/internal/functions/Get-ReadmeContent.ps1
@@ -31,12 +31,12 @@ function Get-ReadmeContent {
   [cmdletbinding()]
   param (
     [OutputType([String])]
-    [string]$PowerShellModuleName,
-    [string]$PowerShellModuleDescription,
-    [string]$PowerShellModuleGalleryUri,
-    [string]$PowerShellModuleProjectUri,
-    [string]$PowerShellModuleVersion,
-    [string]$PuppetModuleName
+    [Parameter(Mandatory=$true)][ValidateNotNullOrEmpty()][string]$PowerShellModuleName,
+    [ValidateNotNullOrEmpty()][string]$PowerShellModuleDescription,
+    [ValidateNotNullOrEmpty()][string]$PowerShellModuleGalleryUri,
+    [ValidateNotNullOrEmpty()][string]$PowerShellModuleProjectUri,
+    [ValidateNotNullOrEmpty()][string]$PowerShellModuleVersion,
+    [Parameter(Mandatory=$true)][ValidateNotNullOrEmpty()][string]$PuppetModuleName
   )
 
   Begin {

--- a/src/internal/functions/Update-PuppetModuleReadme.Tests.ps1
+++ b/src/internal/functions/Update-PuppetModuleReadme.Tests.ps1
@@ -51,6 +51,30 @@ Describe 'Update-PuppetModuleReadme' {
           }
           { Update-PuppetModuleReadme @Parameters  } | Should -Throw "Cannot find path 'TestDrive:\foo\bar' because it does not exist."
         }
+        It 'Errors if the PowerShellModuleManifestPath is not specified' {
+          $Parameters = @{
+            PowerShellModuleName = 'PowerShellGet'
+            PuppetModuleFolderPath = $PuppetFolderPath
+            PuppetModuleName = 'powershellget'
+          }
+          { Update-PuppetModuleReadme @Parameters  } | Should -Throw "Cannot process command because of one or more missing mandatory parameters: PowerShellModuleManifestPath."
+        }
+        It 'Errors if the PowerShellModuleName is not specified' {
+          $Parameters = @{
+            PowerShellModuleManifestPath = 'TestDrive:\foo\bar'
+            PuppetModuleFolderPath = $PuppetFolderPath
+            PuppetModuleName = 'powershellget'
+          }
+          { Update-PuppetModuleReadme @Parameters  } | Should -Throw "Cannot process command because of one or more missing mandatory parameters: PowerShellModuleName."
+        }
+        It 'Errors if the PuppetModuleFolderPath is not specified' {
+          $Parameters = @{
+            PowerShellModuleManifestPath = 'TestDrive:\foo\bar'
+            PowerShellModuleName = 'PowerShellGet'
+            PuppetModuleName = 'powershellget'
+          }
+          { Update-PuppetModuleReadme @Parameters  } | Should -Throw "Cannot process command because of one or more missing mandatory parameters: PuppetModuleFolderPath."
+        }
         It 'Sets the Puppet module name if not specified' {
           $Parameters = @{
             PowerShellModuleManifestPath = $ManifestFilePath
@@ -64,6 +88,47 @@ Describe 'Update-PuppetModuleReadme' {
             $PuppetModuleName -ceq 'override'
           }
           # Unspecified
+          { Update-PuppetModuleReadme @Parameters } | Should -Not -Throw
+          Should -Invoke Get-PuppetizedModuleName -Times 1
+          Should -Invoke Get-ReadmeContent -Times 1 -ParameterFilter {
+            $PuppetModuleName -ceq 'foo'
+          }
+        }
+        It 'Errors if the PowerShellModuleManifestPath is specified as an empty string' {
+          $Parameters = @{
+            PowerShellModuleManifestPath = ''
+            PowerShellModuleName = 'PowerShellGet'
+            PuppetModuleFolderPath = $PuppetFolderPath
+            PuppetModuleName = 'powershellget'
+          }
+          { Update-PuppetModuleReadme @Parameters  } | Should -Throw "Cannot validate argument on parameter 'PowerShellModuleManifestPath'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
+        }
+        It 'Errors if the PowerShellModuleName is specified as an empty string' {
+          $Parameters = @{
+            PowerShellModuleManifestPath = 'TestDrive:\foo\bar'
+            PowerShellModuleName = ''
+            PuppetModuleFolderPath = $PuppetFolderPath
+            PuppetModuleName = 'powershellget'
+          }
+          { Update-PuppetModuleReadme @Parameters  } | Should -Throw "Cannot validate argument on parameter 'PowerShellModuleName'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
+        }
+        It 'Errors if the PuppetModuleFolderPath is specified as an empty string' {
+          $Parameters = @{
+            PowerShellModuleManifestPath = 'TestDrive:\foo\bar'
+            PowerShellModuleName = 'PowerShellGet'
+            PuppetModuleFolderPath = ''
+            PuppetModuleName = 'powershellget'
+          }
+          { Update-PuppetModuleReadme @Parameters  } | Should -Throw "Cannot validate argument on parameter 'PuppetModuleFolderPath'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again."
+        }
+        It 'Sets the Puppet module name if specified as an empty string' {
+          $Parameters = @{
+            PowerShellModuleManifestPath = $ManifestFilePath
+            PowerShellModuleName = 'PowerShellGet'
+            PuppetModuleFolderPath = $PuppetFolderPath
+            PuppetModuleName = ''
+          }
+          # empty
           { Update-PuppetModuleReadme @Parameters } | Should -Not -Throw
           Should -Invoke Get-PuppetizedModuleName -Times 1
           Should -Invoke Get-ReadmeContent -Times 1 -ParameterFilter {

--- a/src/internal/functions/Update-PuppetModuleReadme.ps1
+++ b/src/internal/functions/Update-PuppetModuleReadme.ps1
@@ -22,9 +22,9 @@ function Update-PuppetModuleReadme {
   #>
   [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
   param (
-    [string]$PowerShellModuleManifestPath,
-    [string]$PowerShellModuleName,
-    [string]$PuppetModuleFolderPath,
+    [Parameter(Mandatory=$true)][ValidateNotNullOrEmpty()][string]$PowerShellModuleManifestPath,
+    [Parameter(Mandatory=$true)][ValidateNotNullOrEmpty()][string]$PowerShellModuleName,
+    [Parameter(Mandatory=$true)][ValidateNotNullOrEmpty()][string]$PuppetModuleFolderPath,
     [string]$PuppetModuleName
   )
 


### PR DESCRIPTION
This commit corrects a bug where the auto-generated readme was missing the PowerShell and Puppet module names from various locations in the output markdown.
Those values were not being passed by New-PuppetDscModule to Update-PuppetModuleReadme.

Also includes work to increase parameter validation within `Update-PuppetModuleReadme` and `Get-Readmecontent` to help catch any empty or null values and make parameters mandatory.

Resolves #153