### PR TITLE
(GH-62) Add acceptance testing for multi-module scenario

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -54,7 +54,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2016, windows-2019]
-        tag: [Basic]
+        tag: [Basic, MultiModule]
         pwshlib_source: [forge, git]
         include:
           - pwshlib_source: forge
@@ -77,6 +77,10 @@ jobs:
       - name: Run Tests
         run: |
           $ErrorActionPreference = "Stop"
+          'Reloading Path to pick up installed software'
+          Import-Module C:\ProgramData\chocolatey\helpers\chocolateyProfile.psm1
+          Update-SessionEnvironment
+          Get-Command Puppet, PDK
           $TestParameters = @{
             TestPath         = @((Resolve-Path .\acceptance))
             ResultsPath      = "${{ matrix.results_file }}"

--- a/acceptance/MultiModule.Tests.ps1
+++ b/acceptance/MultiModule.Tests.ps1
@@ -1,0 +1,158 @@
+Param (
+  [string]$PwshLibSource,
+  [string]$PwshLibRepo,
+  [string]$PwshLibReference
+)
+
+Describe 'Acceptance Tests: Multi-Module' -Tag @('Acceptance', 'MultiModule') {
+  BeforeAll {
+    $ModuleRoot = Split-Path $PSCommandPath -Parent |
+      Split-Path -Parent |
+      Join-Path -ChildPath 'src'
+    . "$ModuleRoot\internal\functions\Invoke-PdkCommand.ps1"
+    Import-Module "$ModuleRoot/puppet.dsc.psd1"
+  }
+
+  BeforeDiscovery {
+    $ProjectRoot = Split-Path $PSCommandPath -Parent |
+      Split-Path |
+      Resolve-Path
+    $OutputDirectory = Join-Path (Split-Path $ProjectRoot -Parent) -ChildPath 'modules'
+    $SiteDirectory = Join-Path (Split-Path $ProjectRoot -Parent) -ChildPath 'site'
+
+    Remove-Item -Path $OutputDirectory -Recurse -Force -ErrorAction SilentlyContinue
+    # Ensure the output directory exists and install pwshlib
+    New-Item -Path $OutputDirectory -ItemType Directory -Force
+    If ($null -eq $PwshLibSource -or 'forge' -eq $PwshLibSource) {
+      If ($null -eq $PwshLibRepo) { $PwshLibRepo = 'puppetlabs/pwshlib' }
+      If ([string]::IsNullOrEmpty($PwshLibReference) -or $PwshLibReference -eq 'latest' ) {
+        puppet module install $PwshLibRepo --target-dir $OutputDirectory --force
+        If ($LastExitCode -ne 0) { Throw "Something went wrong installing $PwshLibRepo to $OutputDirectory with Puppet" }
+      } Else {
+        puppet module install $PwshLibRepo --version $PwshLibReference --target-dir $OutputDirectory --force
+        If ($LastExitCode -ne 0) { Throw "Something went wrong installing $PwshLibRepo at $PwshLibReference to $OutputDirectory with Puppet" }
+      }
+    } ElseIf ('git' -eq $PwshLibSource) {
+      If ($null -eq $PwshLibRepo) { Throw 'Specified pwshlib source as git without a repo!' }
+      Push-Location -Path $OutputDirectory
+      git clone $PwshLibRepo pwshlib
+      if ($LastExitCode -ne 0) { Throw "Something went wrong installing $PwshLibRepo to $OutputDirectory with git" }
+      If ($PwshLibReference) {
+        Push-Location -Path (Join-Path -Path $OutputDirectory -ChildPath 'pwshlib')
+        git checkout $PwshLibReference
+        if ($LastExitCode -ne 0) { Throw "Something went wrong checking out $PwshLibReference" }
+        Pop-Location
+      }
+      Pop-Location
+      puppet module list --modulepath $OutputDirectory
+    } Else { Throw "Unexpected pwshlib source: $PwshLibSource" }
+    # Ensure the website test directory exists
+    If (-not (Test-Path $SiteDirectory -PathType Container -ErrorAction SilentlyContinue)) {
+      mkdir $SiteDirectory
+    }
+
+    $ModuleBuildingScenarios = @(
+      @{
+        expected_base    = "$OutputDirectory/xwebadministration"
+        PuppetModuleName = 'xwebadministration'
+        BuildParameters  = @{
+          PowerShellModuleName = 'xWebAdministration'
+          PuppetModuleAuthor   = 'testuser'
+          OutputDirectory      = $OutputDirectory
+        }
+      }
+      @{
+        expected_base    = "$OutputDirectory/xpsdesiredstateconfiguration"
+        PuppetModuleName = 'xpsdesiredstateconfiguration'
+        BuildParameters  = @{
+          PowerShellModuleName = 'xPSDesiredStateConfiguration'
+          PuppetModuleAuthor   = 'testuser'
+          OutputDirectory      = $OutputDirectory
+        }
+      }
+    )
+
+    $WebServerManifest = "$ProjectRoot\examples\webserver\webserver.pp"
+    If (Test-Path $WebServerManifest) {
+      Remove-Item $WebServerManifest
+    }
+    Get-Content "$ProjectRoot\examples\webserver\webserver_template.pp" -Raw | ForEach-Object -Process {
+      $UpdatedContent = $_ -replace '%%SOURCE_PATH%% .+', "'$ProjectRoot/examples/webserver/website'"
+      $UpdatedContent = $UpdatedContent -replace '%%DESTINATION_PATH%% .+', "'$SiteDirectory'"
+      $UpdatedContent = $UpdatedContent -replace '%%WEBSITE_NAME%% .+', "'Puppet DSC Site'"
+      $UpdatedContent = $UpdatedContent -replace '%%SITE_ID%% .+', '7'
+      $UpdatedContent
+    } | New-Item $WebServerManifest
+
+    $IdempotentTestCase = @{
+      ScriptBlock = "puppet apply $WebServerManifest --modulepath $OutputDirectory --verbose --trace *>&1"
+      SiteContent = (Get-Content -Raw -Path "$ProjectRoot\examples\webserver\website\index.html")
+    }
+  }
+
+  Context 'validating build of <puppetmodulename>' -ForEach $ModuleBuildingScenarios {
+    BeforeAll {
+      # Clean up prior builds
+      Remove-Item $expected_base -Force -Recurse -ErrorAction Ignore
+    }
+    It 'is puppetizable' {
+      { New-PuppetDscModule @BuildParameters } | Should -Not -Throw
+    }
+    It 'is buildable' {
+      Invoke-PdkCommand -Path $expected_base -Command "pdk build --target-dir='$($BuildParameters.OutputDirectory)'" -SuccessFilterScript {
+        $_ -match "Build of testuser-$PuppetModuleName has completed successfully."
+      }
+    }
+  }
+
+  Context 'validating idempotency' {
+    BeforeAll {
+      # Ensure IIS is not installed
+      $Feature = Get-WindowsFeature -Name 'Web-Asp-Net45'
+      If ($Feature.Installed) {
+        Remove-WindowsFeature -Name $Feature.Name -ErrorAction Stop
+      }
+      $DefaultSite = Get-Website 'Default Web Site'
+      $ExampleSite = Get-Website 'Puppet DSC Site'
+      If ($DefaultSite.State -eq 'Stopped') {
+        Start-Website -Name $DefaultSite.Name
+      }
+      If ($ExampleSite) {
+        Stop-Website -Name $ExampleSite.Name
+        Remove-Website -Name $ExampleSite.Name
+        Remove-Item -Path $SiteDirectory -Recurse -Force -ErrorAction SilentlyContinue
+      }
+    }
+    It 'idempotently applies without unexpected errors' -TestCases $IdempotentTestCase {
+      $PuppetApply = [scriptblock]::Create($ScriptBlock)
+      $FirstRunResult = Start-Job -ScriptBlock $PuppetApply |
+        Wait-Job | Select-Object -ExpandProperty ChildJobs | Select-Object -First 1
+      $FirstRunOutput = $FirstRunResult.Output -join "`r`n"
+      $FirstRunErrors = $FirstRunResult.Output | Where-Object -FilterScript { $_ -match '^Error: ' }
+      $ExpectedFirstRunErrors = $FirstRunErrors | Where-Object -FilterScript { $_ -match "Please ensure that the PowerShell module for role 'WebAdministration' is installed." }
+      $FirstRunErrors | Should -Be $ExpectedFirstRunErrors
+      $FirstRunOutput | Should -Match "Dsc_xwindowsfeature\[AspNet45\]/dsc_ensure: dsc_ensure changed 'Absent' to 'Present'"
+      $FirstRunOutput | Should -Match 'dsc_xwindowsfeature\[\{:name=>"AspNet45", :dsc_name=>"Web-Asp-Net45"\}\]: Creating: Finished'
+      $FirstRunOutput | Should -Match "Dsc_xwebsite\[DefaultSite\]/dsc_state: dsc_state changed 'Started' to 'Stopped'"
+      $FirstRunOutput | Should -Match "Dsc_xwebsite\[DefaultSite\]/dsc_serverautostart: dsc_serverautostart changed true to 'false'"
+      $FirstRunOutput | Should -Match 'dsc_xwebsite\[\{:name=>"DefaultSite", :dsc_name=>"Default Web Site"\}\]: Updating: Finished'
+      $FirstRunOutput | Should -Match 'File\[.+\]/ensure: defined content'
+      $FirstRunOutput | Should -Match 'Dsc_xwebsite\[NewWebsite\]/dsc_siteid: dsc_siteid changed  to 7'
+      $FirstRunOutput | Should -Match "Dsc_xwebsite\[NewWebsite\]/dsc_ensure: dsc_ensure changed 'Absent' to 'Present'"
+      $FirstRunOutput | Should -Match "Dsc_xwebsite\[NewWebsite\]/dsc_physicalpath: dsc_physicalpath changed  to '.+'"
+      $FirstRunOutput | Should -Match "Dsc_xwebsite\[NewWebsite\]/dsc_state: dsc_state changed  to 'Started'"
+      $FirstRunOutput | Should -Match "Dsc_xwebsite\[NewWebsite\]/dsc_serverautostart: dsc_serverautostart changed  to 'true'"
+      $FirstRunOutput | Should -Match 'dsc_xwebsite\[\{:name=>"NewWebsite", :dsc_name=>"Puppet DSC Site"\}\]: Creating: Finished'
+      # Pending next release of puppetlabs-pwshlib
+      # $FirstRunOutput | Should -Not -Match 'Value type mismatch'
+      $FirstRunOutput | Should -Match 'Notice: Applied catalog'
+      $SecondRunResult = Start-Job -ScriptBlock $PuppetApply |
+        Wait-Job | Select-Object -ExpandProperty ChildJobs | Select-Object -First 1
+      $SecondRunOutput = $FirstRunResult.Output -join "`r`n"
+      $SecondRunOutput | Should -Match 'Notice: Compiled catalog for .+ in environment production'
+      $SecondRunResult.Count | Should -Be 1
+      Invoke-WebRequest -Uri 'http://localhost' -UseBasicParsing |
+        Select-Object -ExpandProperty StatusCode | Should -Be 200
+    }
+  }
+}

--- a/examples/webserver/webserver_template.pp
+++ b/examples/webserver/webserver_template.pp
@@ -1,0 +1,52 @@
+# This example is an adaptation of the MSFT_xWebSite sample code found here:
+# https://github.com/dsccommunity/xWebAdministration/blob/main/source/DSCResources/MSFT_xWebSite/MSFT_xWebSite.psm1
+
+# Declare variables; these should be overwritten for sensible values
+# Our acceptance tests do this: FILE REFERENCE
+$source_path      = %%SOURCE_PATH%%      # 'C:/puppet/webserver/website' # Valid File path for site HTML
+$destination_path = %%DESTINATION_PATH%% # 'C:\Foo'        # Valid File Path for site HTML
+$website_name     = %%WEBSITE_NAME%%     # 'example_site'  # String
+$site_id          = %%SITE_ID%%          # 7               # Integer
+
+# Install the IIS role
+dsc_xwindowsfeature { 'IIS':
+  dsc_ensure => 'Present',
+  dsc_name   => 'Web-Server',
+}
+
+# Install the ASP .NET 4.5 role
+dsc_xwindowsfeature { 'AspNet45':
+  dsc_ensure => 'Present',
+  dsc_name   => 'Web-Asp-Net45',
+}
+
+# Stop the default website
+dsc_xwebsite { 'DefaultSite':
+    dsc_ensure          => 'Present',
+    dsc_name            => 'Default Web Site',
+    dsc_state           => 'Stopped',
+    dsc_serverautostart => false,
+    dsc_physicalpath    => 'C:\inetpub\wwwroot',
+    require             => Dsc_xwindowsfeature['IIS'],
+}
+
+# Copy the website content
+file { 'WebContent':
+    ensure  => directory,
+    recurse => true,
+    replace => true,
+    path    => $destination_path,
+    source  => $source_path,
+    require => Dsc_xwindowsfeature['AspNet45'],
+}
+
+# Create the new Website
+dsc_xwebsite { 'NewWebsite':
+    dsc_ensure          => 'Present',
+    dsc_name            => $website_name,
+    dsc_siteid          => $site_id,
+    dsc_state           => 'Started',
+    dsc_serverautostart => true,
+    dsc_physicalpath    => $destination_path,
+    require             => File['WebContent'],
+}

--- a/examples/webserver/website/index.html
+++ b/examples/webserver/website/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang=en>
+<head>
+<meta charset=utf-8>
+<title>blah</title>
+</head>
+<body>
+<p>I'm the content</p>
+</body>
+</html>

--- a/extras/install.ps1
+++ b/extras/install.ps1
@@ -23,6 +23,10 @@ $PowerShellModules = @(
 
 If ($Full) {
   $ChocolateyPackages += 'pdk'
+  $PuppetInstalled = Get-Command puppet -ErrorAction SilentlyContinue
+  If ($null -eq $PuppetInstalled) {
+    $ChocolateyPackages += 'puppet-agent'
+  }
 }
 
 if ($ENV:CI -ne 'True' -and $Full) {
@@ -48,6 +52,13 @@ If ($Full -or $ENV:CI -eq 'True') {
     winrm create winrm/config/Listener?Address=*+Transport=HTTP
     winrm e winrm/config/listener
   }
+}
+
+$Choco = Get-Command choco -ErrorAction SilentlyContinue
+If ($null -eq $Choco) {
+  Write-Host 'Installing Chocolatey'
+  [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+  Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 }
 
 $Choco = Get-Command choco -ErrorAction SilentlyContinue

--- a/extras/invoke_tests.ps1
+++ b/extras/invoke_tests.ps1
@@ -39,7 +39,7 @@ If ($null -ne $PwshLibSource) {
     PwshLibRepo   = $PwshLibRepo
   }
   # Ignore reference if not specified or specified as latest (needed for CI)
-  If ($null -ne $PwshLibReference -and 'latest' -ne $PwshLibReference) { $Data.PwshLibReference = $PwshLibReference }
+  If (![string]::IsNullOrEmpty($PwshLibReference) -and 'latest' -ne $PwshLibReference) { $Data.PwshLibReference = $PwshLibReference }
   $PesterConfiguration.Run.Container = New-PesterContainer -Path $TestPath -Data $Data
 } Else {
   $PesterConfiguration.Run.Path = $TestPath


### PR DESCRIPTION
Prior to this PR, the only acceptance tests for puppetized modules were single-module and single-resource.

This PR adds a new set of acceptance tests which validate using native Puppet resources and puppetized DSC Resources side by side, and ensures that multiple DSC resources of the same and different type and across modules can interoperate successfully.