### PR TITLE
(MAINT) Move acceptance tests to folder and refactor acceptance testing CI Job

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -95,7 +95,7 @@ jobs:
 
           $testResultsFile = ".\AcceptanceTestsResults.xml"
           $TestPath = @(
-            (Resolve-Path .\Acceptance.Tests.ps1)
+            (Resolve-Path .\acceptance\Basic.Tests.ps1)
           )
 
           $container = New-PesterContainer -Path $TestPath -Data @{ FixtureHash = @{
@@ -131,7 +131,7 @@ jobs:
 
           $testResultsFile = ".\AcceptanceTestsResults.xml"
           $TestPath = @(
-            (Resolve-Path .\Acceptance.Tests.ps1)
+            (Resolve-Path .\Acceptance\Basic.Tests.ps1)
           )
 
           $container = New-PesterContainer -Path $TestPath -Data @{ FixtureHash = @{

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -73,12 +73,16 @@ jobs:
             throw "$($Results.FailedCount) tests failed."
           }
 
-  Acceptance-Forge:
+  Acceptance-Basic:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [windows-2016, windows-2019]
+        pwshlib_source: [forge, git]
+        include:
+          - pwshlib_source: git
+            pwshlib_branch: main
     steps:
       - uses: actions/checkout@v2
       - name: PSVersion Table
@@ -98,47 +102,22 @@ jobs:
             (Resolve-Path .\acceptance\Basic.Tests.ps1)
           )
 
-          $container = New-PesterContainer -Path $TestPath -Data @{ FixtureHash = @{
-            Section = 'forge_modules'
-            Repo    = 'pupptlabs/pwshlib'
-          } }
-          $Results = Invoke-Pester -Container $container -PassThru -Output Detailed
-          $Results | ConvertTo-NunitReport -AsString | Out-File $testResultsFile
-
-          if ($Results.FailedCount -gt 0) {
-            throw "$($Results.FailedCount) tests failed."
+          If ('${{ matrix.pwshlib_source }}' -eq 'forge') {
+            $FixtureHash = @{
+              Section = 'forge_modules'
+              Repo    = 'pupptlabs/pwshlib'
+            }
+          } ElseIf ('${{ matrix.pwshlib_source }}' -eq 'git') {
+            $FixtureHash = @{
+              Section = 'repositories'
+              Repo    = 'git://github.com/puppetlabs/ruby-pwsh.git'
+              Branch  = '${{ matrix.pwshlib_branch }}'
+            }
           }
 
-  Acceptance-Github:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows-2016, windows-2019]
-    steps:
-      - uses: actions/checkout@v2
-      - name: PSVersion Table
-        run: $psversiontable
-      - name: Install
-        run: |
-          $ErrorActionPreference = "Stop"
-          & .\extras\install.ps1 -Full -Verbose
-          if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)  }
-      - name: Run Tests
-        run: |
-          $ErrorActionPreference = "Stop"
-          Import-Module .\src\puppet.dsc.psd1
+          "Fixture Hash:`r`n$($FixtureHash | Out-String)"
 
-          $testResultsFile = ".\AcceptanceTestsResults.xml"
-          $TestPath = @(
-            (Resolve-Path .\Acceptance\Basic.Tests.ps1)
-          )
-
-          $container = New-PesterContainer -Path $TestPath -Data @{ FixtureHash = @{
-            Section = 'repositories'
-            Repo    = 'git://github.com/puppetlabs/ruby-pwsh.git'
-            Branch  = 'main'
-          } }
+          $container = New-PesterContainer -Path $TestPath -Data @{ FixtureHash = $FixtureHash }
           $Results = Invoke-Pester -Container $container -PassThru -Output Detailed
           $Results | ConvertTo-NunitReport -AsString | Out-File $testResultsFile
 

--- a/acceptance/Basic.Tests.ps1
+++ b/acceptance/Basic.Tests.ps1
@@ -2,16 +2,16 @@ Param (
   [hashtable]$FixtureHash
 )
 
-BeforeDiscovery {
-}
 BeforeAll {
-  $ModuleRoot = Split-Path $PSCommandPath -Parent | Join-Path -ChildPath 'src'
-  . .\src\internal\functions\Invoke-PdkCommand.ps1
+  $ModuleRoot = Split-Path $PSCommandPath -Parent |
+    Split-Path -Parent |
+    Join-Path -ChildPath 'src'
+  . "$ModuleRoot\internal\functions\Invoke-PdkCommand.ps1"
   Import-Module "$ModuleRoot/puppet.dsc.psd1"
   $Script = $PSCommandPath.Replace('5.Tests.ps1', '.ps1')
 }
 
-Describe 'Acceptance Tests' -Tag 'acceptance' {
+Describe 'Acceptance Tests: Basic' -Tag 'basic' {
   BeforeDiscovery {
     $PSDscRunAsCredentialUsername = 'Foo'
     $PSDscRunAsCredentialPassword = 'This is a pretty long phrase, to be quite honest! :)'
@@ -281,5 +281,4 @@ Describe 'Acceptance Tests' -Tag 'acceptance' {
       }
     }
   }
-
 }


### PR DESCRIPTION
This commit moves the acceptance tests to their own folder in preparation for adding multiple acceptance test files. In the current design, all acceptance tests would need to live in a single file which makes it hard to maintain and reason about.

This commit moves the existing acceptance tests to acceptance/Basic.Tests.ps1 and updates the CI config to look in the correct place.