### PR TITLE
(MAINT) Update install script and vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -60,7 +60,7 @@ Vagrant.configure("2") do |config|
     }
   end
 
-  config.vm.provision "shell", path: 'extras/install.ps1'
+  config.vm.provision "shell", path: 'extras/install.ps1', args: '-Full'
   profile_destination = 'C:\Users\vagrant\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1'
   config.vm.provision "file", source: "./extras/profile.ps1", destination: profile_destination
 end

--- a/extras/install.ps1
+++ b/extras/install.ps1
@@ -5,7 +5,9 @@ Param(
 
 $ErrorActionPreference = 'Stop'
 
-$ChocolateyPackages = @('Pester')
+$ChocolateyPackages = @(
+  'Pester'
+)
 
 $PowerShellModules = @(
   @{ Name = 'PSFramework' }
@@ -31,26 +33,40 @@ if ($ENV:CI -ne 'True' -and $Full) {
     'git'
     'poshgit'
     'curl'
+    'conemu'
   )
   $PowerShellModules += @(
     @{ Name = 'RubyInstaller' }
   )
 }
 
-Write-Host 'Ensuring WinRM is configured for DSC'
-Get-ChildItem WSMan:\localhost\Listener\ -OutVariable Listeners | Format-List * -Force
-$HTTPListener = $Listeners | Where-Object -FilterScript { $_.Keys.Contains('Transport=HTTP') }
-If ($HTTPListener.Count -eq 0) {
-  winrm create winrm/config/Listener?Address=*+Transport=HTTP
-  winrm e winrm/config/listener
+If ($Full -or $ENV:CI -eq 'True') {
+  Write-Host 'Ensuring WinRM is configured for DSC'
+  Get-ChildItem WSMan:\localhost\Listener\ -OutVariable Listeners | Format-List * -Force
+  $HTTPListener = $Listeners | Where-Object -FilterScript { $_.Keys.Contains('Transport=HTTP') }
+  If ($HTTPListener.Count -eq 0) {
+    winrm create winrm/config/Listener?Address=*+Transport=HTTP
+    winrm e winrm/config/listener
+  }
+}
+
+$Choco = Get-Command choco -ErrorAction SilentlyContinue
+If ($null -eq $Choco) {
+  Write-Host 'Installing Chocolatey'
+  [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+  Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 }
 
 Write-Host "Installing with choco: $ChocolateyPackages"
 
-choco install $ChocolateyPackages --yes --no-progress --stop-on-first-failure
+choco install $ChocolateyPackages --yes --no-progress --stop-on-first-failure --ignore-checksums
 if ($LastExitCode -ne 0) {
   throw 'Installation with choco failed.'
 }
+
+Write-Host 'Reloading Path to pick up installed software'
+Import-Module C:\ProgramData\chocolatey\helpers\chocolateyProfile.psm1
+Update-SessionEnvironment
 
 Get-Module -ListAvailable -Name $PowerShellModules.Name -ErrorAction SilentlyContinue
 
@@ -74,9 +90,7 @@ ForEach ($Module in $PowerShellModules) {
 
 Get-Module -ListAvailable -Name $PowerShellModules.Name
 
-if ($ENV:CI -ne 'True') {
+if ($ENV:CI -ne 'True' -and $Full) {
   Import-Module 'RubyInstaller'
-  # Non-functional, pending an investigation and PR to RubyInstaller?
-  # For now you need to run it interactively
-  # Install-Ruby -RubyVersions '2.5.1' -Verbose
+  Install-Ruby -RubyVersions @('2.5.1-2 (x64)', '2.7.2-1 (x64)') -Verbose
 }


### PR DESCRIPTION
This commit updates the vagrant file to install the full suite of software for development and testing.

It also updates the install script to:

- Fixup the style where needed
- Add conemu to the list of software to install outside of CI
- Only set WinRM if the Full flag is passed
- Install chocolatey if it is not already installed
- Update the session environment after installing software
- Turn on installing multiple dev rubies for use outside of CI