### PR TITLE
(GH-172) Add implementation to generated types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Ability to invoke class-based resources by adding the `dscmeta_resource_implementation` key in the generated types; functionality requires [puppetlabs-pwshlib](https://forge.puppet.com/modules/puppetlabs/pwshlib) `0.10.0` or higher ([#172](https://github.com/puppetlabs/ruby-pwsh/issues/172))
+
 ## [0.6.0] - 2021-6-28
 
 ### Added

--- a/src/internal/functions/Get-DscResourceImplementation.Tests.ps1
+++ b/src/internal/functions/Get-DscResourceImplementation.Tests.ps1
@@ -1,0 +1,126 @@
+Describe 'Get-DscResourceImplementation' -Tag 'Unit' {
+  BeforeAll {
+    . $PSCommandPath.Replace('.Tests.ps1', '.ps1')
+
+    # The using statement will fail without a correct module path;
+    # The scriptblock in Start-Job can't see the Pester TestDrive,
+    # so instead we need to point to a real module path.
+    $TestModulePath = Get-Module -Name Pester | Select-Object -ExpandProperty Path
+
+    $NonPowerShellDscResources = [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo[]]@(
+      @{ Name = 'foo' ; ImplementedAs = 'Binary' }
+      @{ Name = 'bar' ; ImplementedAs = 'None' }
+    )
+    $PowerShellDscResources = [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo[]]@(
+      @{ Name = 'classy' ; ImplementedAs = 'PowerShell' ; Path = $TestModulePath }
+      @{ Name = 'mofy' ; ImplementedAs = 'PowerShell' ; Path = $TestModulePath }
+    )
+  }
+
+  Context 'when the Resource is passed explicitly' {
+    BeforeEach {
+      Mock Get-DscResource {}
+    }
+
+    It 'never calls Get-DscResource' {
+      $null = $NonPowerShellDscResources | Get-DscResourceImplementation
+      Should -Invoke Get-DscResource -Times 0 -Scope It
+    }
+
+    It 'processes once for each object in the pipeline' {
+      $Result = $NonPowerShellDscResources | Get-DscResourceImplementation
+      $Result.Count | Should -Be 2
+    }
+  }
+
+  Context 'when the Resource is passed by name' {
+    BeforeAll {
+      Mock Get-DscResource {
+        [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo]@{ Name = $Name ; ImplementedAs = 'Binary' }
+      }
+    }
+    It 'calls Get-DscResource by name' {
+      $null = Get-DscResourceImplementation -Name 'foo'
+      Should -Invoke Get-DscResource -Times 1 -Scope It
+      Should -Invoke Get-DscResource -Times 1 -Scope It -ParameterFilter { $Name -eq 'foo' }
+    }
+  }
+
+  Context 'when the Resource is passed by name and module' {
+    BeforeAll {
+      Mock Get-DscResource {
+        [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo]@{ Name = $Name ; ImplementedAs = 'Binary' }
+      }
+    }
+    It 'calls Get-DscResource by name and module' {
+      $null = Get-DscResourceImplementation -Name 'foo' -Module 'bar'
+      Should -Invoke Get-DscResource -Times 1 -Scope It
+      Should -Invoke Get-DscResource -Times 1 -Scope It -ParameterFilter { $Name -eq 'foo' -and $Module -eq 'bar' }
+    }
+  }
+
+  Context "when the Resource's ImplementedAs value is not PowerShell" {
+    It 'sets the resource implementation to the ImplementedAs value' {
+      $Result = $NonPowerShellDscResources | Get-DscResourceImplementation
+      $Result.Count | Should -Be 2
+      $Result[0] | Should -Be 'Binary'
+      $Result[1] | Should -Be 'None'
+    }
+  }
+
+  Context "when the Resource's ImplementedAs value is PowerShell" {
+    It 'starts and waits for a job once per resource' {
+      $JobOutput = 'ScriptBlock Output'
+      Mock Start-Job {
+        [PSCustomObject]@{ID = 0 }
+      }
+      Mock Wait-Job {
+        return @{
+          ChildJobs = [System.Collections.ArrayList]@(
+            @{ Output = $JobOutput }
+          )
+        }
+      }
+
+      $null = $PowerShellDscResources | Get-DscResourceImplementation
+      Should -Invoke -CommandName 'Start-Job' -Times 2 -Scope It -ParameterFilter {
+        $ScriptBlock.ToString() -match [Regex]::Escape("using module '$TestModulePath'")
+        $ScriptBlock.ToString() -match "('classy'|'mofy') -as \[type\]"
+      }
+      Should -Invoke -CommandName 'Wait-Job' -Times 2 -Scope It
+    }
+
+    Context 'when the Resource is class-based' {
+      It "sets the resource implementation to 'Class'" {
+        # We actually want to run the scriptblock, so don't mock the *Job functions
+        $DscResource = [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo]@{
+          # String isn't a DSC Resource, but it works for test purposes
+          Name = 'String' ; ImplementedAs = 'PowerShell' ; Path = $TestModulePath
+        }
+        $DscResource | Get-DscResourceImplementation | Should -Be 'Class'
+      }
+    }
+
+    Context 'when the Resource is MOF-based' {
+      It "sets the resource implementation to 'MOF'" {
+        # We actually want to run the scriptblock, so don't mock the *Job functions
+        $DscResource = [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo]@{
+          Name = 'Mofy' ; ImplementedAs = 'PowerShell' ; Path = $TestModulePath
+        }
+        $DscResource | Get-DscResourceImplementation | Should -Be 'MOF'
+      }
+    }
+  }
+
+  Context 'when the ModifyResource switch is specified' {
+    It 'adds the ResourceImplementation note property to the input resource' {
+      $DscResource = [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo]@{
+        Name = 'Foo' ; ImplementedAs = 'Binary'
+      }
+      $null = $DscResource | Get-DscResourceImplementation -ModifyResource
+      $DscResource.Name | Should -Be 'Foo'
+      $DscResource.ResourceImplementation | Should -Be 'Binary'
+    }
+  }
+}
+

--- a/src/internal/functions/Get-DscResourceImplementation.ps1
+++ b/src/internal/functions/Get-DscResourceImplementation.ps1
@@ -1,0 +1,128 @@
+Function Get-DscResourceImplementation {
+  <#
+    .SYNOPSIS
+      Determine the granular implementation of a DSC Resource
+
+    .DESCRIPTION
+      This function leverages the Get-DscResource command and a generative scriptblock to determine
+      whether a DSC Resource with an `ImplementedAs` value of `PowerShell` is class-based or mof-based
+      and, for other values of `ImplementedAs`, returns those values directly. If the `ModifyResource`
+      switch is passed, this function returns the full DSC Resource info object with a new note property,
+      `ResourceImplementation`, which is the value normally returned from this function.
+
+    .PARAMETER DscResource
+      The DscResourceInfo object to introspect; can be passed via the pipeline, normally retrieved
+      via calling Get-DscResource.
+
+    .PARAMETER Name
+      If not passing a full object, specify the name of the DSC Resource to retrieve and introspect.
+
+    .PARAMETER Module
+      If not passing a full object, specify the module name of the the DSC Resource to retrieve and introspect.
+      Can be either a string or a hash containing the keys ModuleName and ModuleVersion.
+
+    .PARAMETER ModifyResource
+      If this switch is specified the function adds the implementation type as the `ResourceImplementation`
+      note property to the DSC Resource info object being inspected.
+
+    .EXAMPLE
+      Get-DscResource -Name PSRepository | Get-DscResourceImplementation
+
+      Return the implementation for PSRepository as a string
+
+    .EXAMPLE
+      Get-DscResource -Name PSRepository | Get-DscResourceImplementation
+
+      Return the DSC Resource info object for PSRepository with the `ResourceImplementation`
+      note property added to it.
+
+    .EXAMPLE
+      Get-DscResourceImplementation -DscResourceName PSRepository
+
+      Return the implementation for PSRepository as a string, retrieving the DSC Resource info via
+      `Get-DscResource`. Will ONLY find the resource if it is in the PSModulePath.
+
+    .NOTES
+      This function currently takes EITHER:
+
+      1. A DscResource Object, as passed by Get-DSCResource
+      2. A combo of name/module to retrieve DSC Resources from
+  #>
+  [CmdletBinding(
+    DefaultParameterSetName = 'ByObject'
+  )]
+  [OutputType([String], [String[]])]
+  Param(
+    [Parameter(
+      ValueFromPipeline,
+      ParameterSetName = 'ByObject'
+    )]
+    [Microsoft.PowerShell.DesiredStateConfiguration.DscResourceInfo[]]$DscResource,
+
+    [Parameter(
+      ValueFromPipelineByPropertyName,
+      ParameterSetName = 'ByProperty'
+    )]
+    [string[]]$Name,
+
+    [Parameter(
+      ValueFromPipelineByPropertyName,
+      ParameterSetName = 'ByProperty'
+    )]
+    [object]$Module,
+    [switch]$ModifyResource
+  )
+
+  Begin { }
+
+  Process {
+    # Retrieve the DSC Resource information from the system unless passed directly
+    If ($null -eq $DscResource) {
+      if ($null -eq $Module) {
+        $DscResourceToProcess = Get-DscResource -Name $Name -ErrorAction Stop
+      } else {
+        $DscResourceToProcess = Get-DscResource -Name $Name -Module $Module -ErrorAction Stop
+      }
+    } Else {
+      $DscResourceToProcess = $DscResource
+    }
+    ForEach ($Resource in $DscResourceToProcess) {
+      If ($Resource.ImplementedAs -eq 'PowerShell') {
+        $Module = Resolve-Path -Path $Resource.Path
+        $ScriptBlock = [ScriptBlock]::Create("
+          using module '$Module'
+          Try {
+            `$ErrorActionPreference = 'Stop'
+            `$null = [$($Resource.Name)]
+            'Class'
+          } Catch {
+            'MOF'
+          }
+          # If ('$($Resource.Name)' -as [type]) {
+          #   'Class'
+          # } Else {
+          #   'MOF'
+          # }
+        ")
+        $ClassTestJob = Start-Job -ScriptBlock $ScriptBlock | Wait-Job
+
+        $DscResourceImplementation = $ClassTestJob.ChildJobs[0].Output
+      } Else {
+        $DscResourceImplementation = $Resource.ImplementedAs
+      }
+      If ($ModifyResource) {
+        $Parameters = @{
+          MemberType = 'NoteProperty'
+          Name       = 'ResourceImplementation'
+          Value      = $DscResourceImplementation
+          PassThru   = $True
+        }
+        $Resource | Add-Member @Parameters
+      } Else {
+        [string]$DscResourceImplementation
+      }
+    }
+  }
+
+  End {}
+}

--- a/src/internal/functions/Get-DscResourceTypeInformation.Tests.ps1
+++ b/src/internal/functions/Get-DscResourceTypeInformation.Tests.ps1
@@ -8,7 +8,7 @@ Describe 'Get-DscResourceTypeInformation' -Tag 'Unit' {
   }
 
   InModuleScope puppet.dsc {
-    Context 'When running <ElevationStatus>' -Foreach @(
+    Context 'When running <ElevationStatus>' -ForEach @(
       @{
         ElevationStatus = 'elevated'
         TestResult      = $true
@@ -24,6 +24,7 @@ Describe 'Get-DscResourceTypeInformation' -Tag 'Unit' {
         Mock Test-RunningElevated { return $TestResult }
         Mock Get-DscResourceParameterInfoByCimClass { return $DscResource.Name }
         Mock Get-DscResourceParameterInfo { return $DscResource.Name }
+        Mock Get-DscResourceImplementation { }
       }
       Context 'When passed a DSCResourceInfo object' {
         BeforeAll {
@@ -43,6 +44,7 @@ Describe 'Get-DscResourceTypeInformation' -Tag 'Unit' {
         It 'processes once for each object in the pipeline' -TestCases $TestCase {
           $Result = $DscResources | Get-DscResourceTypeInformation
           Should -Invoke $QueryFunction -Times 2 -Scope It
+          Should -Invoke Get-DscResourceImplementation -Times 2 -Scope It
           $Result[0].ParameterInfo | Should -Be $Result[0].Name
         }
         It 'never calls Get-DscResource' {
@@ -114,6 +116,7 @@ Describe 'Get-DscResourceTypeInformation' -Tag 'Unit' {
           It 'processes once for each resource found' {
             Should -Invoke Get-DscResource -Times 2 -Scope Context
             Should -Invoke $QueryFunction -Times 2 -Scope Context
+            Should -Invoke Get-DscResourceImplementation -Times 2 -Scope Context
           }
         }
       }

--- a/src/internal/functions/Get-DscResourceTypeInformation.ps1
+++ b/src/internal/functions/Get-DscResourceTypeInformation.ps1
@@ -74,8 +74,15 @@ Function Get-DscResourceTypeInformation {
     } Else {
       $DscResourceToProcess = $DscResource
     }
+
+    # Ensure we know the DSC Resource Type; unfortunately, DSC does not distinguish
+    # between MOF-based DSC Resources and Class-based DSC Resources, they are both
+    # designated ImplementedAs 'PowerShell' - updating the resource in place here
+    # can happen regardless of PowerShell version or administrative privileges.
+    $null = $DscResourceToProcess | Get-DscResourceImplementation -ModifyResource
+
     ForEach ($Resource in $DscResourceToProcess) {
-      $Value = If ($RunningElevated -and ($DscResource.ImplementedAs -ne 'Composite')) {
+      $Value = If ($RunningElevated -and ($Resource.ImplementedAs -ne 'Composite')) {
         Get-DscResourceParameterInfoByCimClass -DscResource $Resource
       } Else {
         Get-DscResourceParameterInfo -DscResource $Resource

--- a/src/internal/functions/Get-ReadmeContent.ps1
+++ b/src/internal/functions/Get-ReadmeContent.ps1
@@ -164,6 +164,12 @@ dsc_psrepository { 'PowerShell Gallery':
 }
 ``````
 
+### Class-Based Resources
+
+Class-based DSC Resources can be used like any other DSC Resource in this module, with one important note:
+Due to a bug in calling class-based DSC Resources by path instead of module name, each call to ``Invoke-DscResource`` needs to temporarily munge the system-level environment variable for ``PSModulePath``;
+the variable is reset prior to the end of each invocation.
+
 ### CIM Instances
 
 Because the CIM instances for DSC resources are fully mapped, the types actually explain fairly precisely what the shape of each CIM instance has to be - and, moreover, the type definition means that you get checking at catalog compile time.
@@ -272,6 +278,10 @@ For specific information on troubleshooting a generated module, check the [troub
 
 Currently, because of the way Puppet caches files on agents, use of the legacy [``puppetlabs-dsc``]($LegacyDscForgePage) module is **not** compatible with this or any auto-generated DSC module.
 Inclusion of both will lead to pluginsync conflicts.
+
+Right now, if you have the same version of a PowerShell module with class-based DSC Resources in your PSModulePath as vendored in a Puppetized DSC Module,
+you cannot use those class-based DSC Resources from inside of Puppet due to a bug in DSC which prevents using a module by path reference instead of name.
+Instead, DSC will see that there are two DSC Resources for the same module and version and then error out.
 
 ### Configuring the LCM
 

--- a/src/internal/functions/Get-TypeContent.Tests.ps1
+++ b/src/internal/functions/Get-TypeContent.Tests.ps1
@@ -25,6 +25,7 @@ Describe 'Get-TypeContent' -Tag 'Unit' {
         $Result | Should -MatchExactly "name: 'dsc_archive'"
         $Result | Should -MatchExactly "dscmeta_resource_friendly_name: 'Archive'"
         $Result | Should -MatchExactly "dscmeta_resource_name: 'MSFT_Archive'"
+        $Result | Should -MatchExactly "dscmeta_resource_implementation: 'MOF'"
         $Result | Should -MatchExactly "dscmeta_module_name: 'PSDscResources'"
         $Result | Should -MatchExactly "dscmeta_module_version: '2.12.0.0'"
         $Result | Should -MatchExactly 'The DSC Archive resource type.'

--- a/src/internal/functions/Get-TypeContent.ps1
+++ b/src/internal/functions/Get-TypeContent.ps1
@@ -50,6 +50,7 @@ Puppet::ResourceApi.register_type(
   name: 'dsc_$($Resource.Name.ToLowerInvariant())',
   dscmeta_resource_friendly_name: '$FriendlyName',
   dscmeta_resource_name: '$($Resource.ResourceType)',
+  dscmeta_resource_implementation: '$($Resource.ResourceImplementation)',
   dscmeta_module_name: '$($Resource.ModuleName)',
   dscmeta_module_version: '$($Resource.Version)',
   docs: $(ConvertTo-PuppetRubyString $ResourceDescription),


### PR DESCRIPTION
Prior to this PR, the generated types did not include their implementation information.

This PR ensures that granular implementation information is added to the `dscmeta_resource_implementation` key, distinguishing between MOF-based, class-based, binary, and composite implementations instead of only Powershell/binary/composite.

To do so, this PR:

1. Adds the `Get-PowerShellDscResourceType` private function, which has logic to determine if a DSC Resource with an `ImplementedAs` value of `PowerShell` is MOF-based or class-based
2. Ensures that the `Get-DscResourceTypeInformation` private function uses `Get-PowerShellDscResourceType` to capture the implementation of the DSC Resource being introspected
3. Ensures that the `dscmeta_resource_implementation` key is added to the generated Puppet Resource API type definition for DSC Resources, using the value as determined in `Get-PowerShellDscResourceType`

This change is backwards compatible as it _adds_ a new key to the type definition instead of changing any existing keys.

As referenced in (ADD 172 REFERENCE LATER), this improvement will enable the base provider to invoke class-based DSC Resources by munging the system PSModulePath environment variable _only_ when necessary, instead of for all resource invocations.

## TODO:

- [x] Add acceptance test for class-based resources
- [x] Add unit tests
- [x] Ensure all existing tests pass (update if necessary)
- [x] Document behavior in the generated README
- [x] Document limitation - cannot have the same module version in the PSModulePath when calling a class-based Resource
- [x] Write changelog entry