### PR TITLE
(MAINT) Define nested cim instance types as enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ability to invoke class-based resources by adding the `dscmeta_resource_implementation` key in the generated types; functionality requires [puppetlabs-pwshlib](https://forge.puppet.com/modules/puppetlabs/pwshlib) `0.10.0` or higher ([#172](https://github.com/puppetlabs/ruby-pwsh/issues/172))
 
+### Fixed
+
+- Ensure Puppet type definition for nested cim instances declares the CIM Instance type as a single-value enum to prevent runtime errors when parsing them ([#180](https://github.com/puppetlabs/Puppet.Dsc/issues/180))
+
 ## [0.6.0] - 2021-6-28
 
 ### Added

--- a/src/internal/functions/Get-DscResourceParameterInfoByCimClass.Tests.ps1
+++ b/src/internal/functions/Get-DscResourceParameterInfoByCimClass.Tests.ps1
@@ -51,6 +51,7 @@ Describe 'Get-DscResourceParameterInfoByCimClass' -Skip:(!$RunningElevated) -Tag
         # This function currently cannot discover default values
         $AclProperty.DefaultValue      | Should -BeNullOrEmpty
         $AclProperty.Type              | Should -MatchExactly ([Regex]::Escape('Array[Struct[{'))
+        $AclProperty.Type              | Should -MatchExactly ([Regex]::Escape("cim_instance_type => Enum['NTFSAccessControlEntry']"))
         $AclProperty.Help              | Should -MatchExactly '^Indicates the access control information'
         $AclProperty.is_parameter      | Should -Be $false
         $AclProperty.is_namevar        | Should -BeExactly 'false'

--- a/src/internal/functions/Get-DscResourceParameterInfoByCimClass.ps1
+++ b/src/internal/functions/Get-DscResourceParameterInfoByCimClass.ps1
@@ -48,7 +48,7 @@ Function Get-DscResourceParameterInfoByCimClass {
           # Capture the metadata in order to parse the Puppet type definition and retrieve the cim instance types.
           $EmbeddedInstanceMetadata = @{}
           $EmbeddedInstanceMetadata.$InstanceType = @{
-            cim_instance_type = "'$InstanceType'"
+            cim_instance_type = "Enum['$InstanceType']"
           }
           $CimClassProperties = Get-CimClassPropertiesList -ClassName $InstanceType
           ForEach ($Property in $CimClassProperties) {
@@ -120,7 +120,7 @@ Function Get-DscResourceParameterInfoByCimClass {
         # Split the definition for the struct and toss away the cim_instance_type key as this is a top-level property
         # and that information is captured in the mof_type key already.
         $SplitDefinition = $DefinedEmbeddedInstances.($Property.ReferenceClassName) -split "`n" |
-          Where-Object -FilterScript { $_ -notmatch "cim_instance_type => '$($Property.ReferenceClassName)'" }
+          Where-Object -FilterScript { $_ -notmatch "cim_instance_type => Enum\['$($Property.ReferenceClassName)'\]" }
         # Recombine the struct definition appropriately mapped as an array or singleton
         If ($Property.CimType -match 'Array') {
           $PuppetType = "Array[$($SplitDefinition -Join "`n")]"


### PR DESCRIPTION
Prior to this PR the builder defined the Puppet type for a nested cim instance's type as a string of its value, ie `'SomeInstanceType'`.

This caused runtime errors when passing the `cim_instance_type` during a Puppet run as this is not a valid data type.

This PR updates the mapping of a nested CIM Instance into a Puppet property by defining the `cim_instance_type` as a single-value enum, such as `Enum['SomeINstanceType']` - this obviates the runtime error.