### PR TITLE
(WIP) Add workflow to repuppetize modules

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -27,71 +27,71 @@ jobs:
             results_file: Unit.Results.xml
     steps:
       - uses: actions/checkout@v2
-      - name: PSVersion Table
-        run: $psversiontable
-      - name: Install
-        run: |
-          $ErrorActionPreference = "Stop"
-          & .\extras\install.ps1 -Verbose
-          if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)  }
-      - name: Run Tests
-        run: |
-          $ErrorActionPreference = "Stop"
-          $ResultsPath = "${{ matrix.results_file }}"
-          $TestPath = @(
-            (Resolve-Path .\src\functions)
-            (Resolve-Path .\src\internal\functions)
-            (Resolve-Path .\src\tests\general)
-          )
-          $Results = .\extras\invoke_tests.ps1 -TestPath $TestPath -ResultsPath $ResultsPath -Tag ${{ matrix.tag }}
-          if ($Results.FailedCount -gt 0) {
-            throw "$($Results.FailedCount) tests failed."
-          }
+#       - name: PSVersion Table
+#         run: $psversiontable
+#       - name: Install
+#         run: |
+#           $ErrorActionPreference = "Stop"
+#           & .\extras\install.ps1 -Verbose
+#           if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)  }
+#       - name: Run Tests
+#         run: |
+#           $ErrorActionPreference = "Stop"
+#           $ResultsPath = "${{ matrix.results_file }}"
+#           $TestPath = @(
+#             (Resolve-Path .\src\functions)
+#             (Resolve-Path .\src\internal\functions)
+#             (Resolve-Path .\src\tests\general)
+#           )
+#           $Results = .\extras\invoke_tests.ps1 -TestPath $TestPath -ResultsPath $ResultsPath -Tag ${{ matrix.tag }}
+#           if ($Results.FailedCount -gt 0) {
+#             throw "$($Results.FailedCount) tests failed."
+#           }
 
-  Acceptance:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows-2016, windows-2019]
-        tag: [Basic, MultiModule]
-        pwshlib_source: [forge, git]
-        include:
-          - pwshlib_source: forge
-            pwshlib_repo: "puppetlabs/pwshlib"
-            pwshlib_ref: "latest" # Change to a specific version if desired
-            results_file: Acceptance.Forge.Results.xml
-          - pwshlib_source: git
-            pwshlib_repo: "git://github.com/puppetlabs/ruby-pwsh.git" # Change to another fork if desired
-            pwshlib_ref: main # Change to another branch if desired
-            results_file: Acceptance.Git.Results.xml
-    steps:
-      - uses: actions/checkout@v2
-      - name: PSVersion Table
-        run: $psversiontable
-      - name: Install
-        run: |
-          $ErrorActionPreference = "Stop"
-          & .\extras\install.ps1 -Full -Verbose
-          if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)  }
-      - name: Run Tests
-        run: |
-          $ErrorActionPreference = "Stop"
-          'Reloading Path to pick up installed software'
-          Import-Module C:\ProgramData\chocolatey\helpers\chocolateyProfile.psm1
-          Update-SessionEnvironment
-          Get-Command Puppet, PDK
-          $TestParameters = @{
-            TestPath         = @((Resolve-Path .\acceptance))
-            ResultsPath      = "${{ matrix.results_file }}"
-            Tag              = "${{ matrix.tag }}"
-            PwshLibSource    = "${{ matrix.pwshlib_source }}"
-            PwshLibRepo      = "${{ matrix.pwshlib_repo }}"
-            PwshLibReference = "${{ matrix.pwshlib_ref }}"
-          }
-          "Invocation Parameters: `r`n$($TestParameters | ConvertTo-Json)"
+#   Acceptance:
+#     runs-on: ${{ matrix.os }}
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         os: [windows-2016, windows-2019]
+#         tag: [Basic, MultiModule]
+#         pwshlib_source: [forge, git]
+#         include:
+#           - pwshlib_source: forge
+#             pwshlib_repo: "puppetlabs/pwshlib"
+#             pwshlib_ref: "latest" # Change to a specific version if desired
+#             results_file: Acceptance.Forge.Results.xml
+#           - pwshlib_source: git
+#             pwshlib_repo: "git://github.com/puppetlabs/ruby-pwsh.git" # Change to another fork if desired
+#             pwshlib_ref: main # Change to another branch if desired
+#             results_file: Acceptance.Git.Results.xml
+#     steps:
+#       - uses: actions/checkout@v2
+#       - name: PSVersion Table
+#         run: $psversiontable
+#       - name: Install
+#         run: |
+#           $ErrorActionPreference = "Stop"
+#           & .\extras\install.ps1 -Full -Verbose
+#           if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)  }
+#       - name: Run Tests
+#         run: |
+#           $ErrorActionPreference = "Stop"
+#           'Reloading Path to pick up installed software'
+#           Import-Module C:\ProgramData\chocolatey\helpers\chocolateyProfile.psm1
+#           Update-SessionEnvironment
+#           Get-Command Puppet, PDK
+#           $TestParameters = @{
+#             TestPath         = @((Resolve-Path .\acceptance))
+#             ResultsPath      = "${{ matrix.results_file }}"
+#             Tag              = "${{ matrix.tag }}"
+#             PwshLibSource    = "${{ matrix.pwshlib_source }}"
+#             PwshLibRepo      = "${{ matrix.pwshlib_repo }}"
+#             PwshLibReference = "${{ matrix.pwshlib_ref }}"
+#           }
+#           "Invocation Parameters: `r`n$($TestParameters | ConvertTo-Json)"
 
-          $Results = .\extras\invoke_tests.ps1 @TestParameters
-          if ($Results.FailedCount -gt 0) {
-            throw "$($Results.FailedCount) tests failed."
-          }
+#           $Results = .\extras\invoke_tests.ps1 @TestParameters
+#           if ($Results.FailedCount -gt 0) {
+#             throw "$($Results.FailedCount) tests failed."
+#           }

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,76 @@
+# When Puppet.Dsc is tagged and released, rebuild all modules from the latest version on the gallery
+name: Update
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: powershell
+
+jobs:
+  setup_matrix:
+    name: "Setup Matrix"
+    runs-on: windows-latest
+    outputs:
+      module_groups: ${{ steps.build-matrix.outputs.module_groups }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Get Latest Tag
+        id: latest_tag
+        run: |
+          $TagVersion = git tag --list |
+            ForEach-Object -Process { [version]$_.Trim() } |
+            Sort-Object -Descending |
+            Select-Object -First 1
+          echo "::set-output name=tag::$($TagVersion.ToString())"
+      - name: PSVersion Table
+        run: $psversiontable
+      - name: Install PowerShell Prerequisites
+        run: |
+          Import-Module PowerShellGet
+          $InstallParameters = @{
+            Name = 'Puppet.Dsc'
+            RequiredVersion = '${{ steps.latest_tag.outputs.tag }}'
+            Scope = 'AllUsers'
+            Force = $True
+            Verbose = $True
+            ErrorAction = 'Stop'
+          }
+          Install-Module @InstallParameters
+      - name: Generate Module Groups
+        run: |
+          Import-Module Puppet.Dsc
+          $VerbosePreference = 'Continue'
+          Try {
+            # Retrieve the Puppetized Modules from the Forge
+            $PuppetizedModules = Get-ForgeModuleInfo -ForgeNameSpace 'dsc' -ErrorAction Stop |
+              Select-Object -ExpandProperty Name
+            # Instantiate the matrix groups and fill them
+            $Groups = [pscustomobject]@{}
+            ForEach ($GroupNumber in 1..20) {
+              $Parameters = @{
+                MemberType = 'NoteProperty'
+                Name = "Group$GroupNumber"
+                Value = [System.Collections.Generic.List[string]]@()
+              }
+              $Groups | Add-Member @Parameters
+            }
+            foreach ($ModuleEntry in 0..$PuppetizedModules.Count) {
+              $GroupNumber = ($ModuleEntry % 20) + 1
+              $Groups."Group$GroupNumber".Add($PuppetizedModules[$ModuleEntry])
+            }
+            echo "Modules to Rebuild & Release by Group:"
+            ForEach ($GroupNumber in 1..20) {
+              echo "Group ${GroupNumber}: $($Groups."Group$GroupNumber" | % { "`r`n`t$_" })"
+            }
+            echo "::set-output name=module_groups::$($Groups | ConvertTo-Json -Compress -Depth 5)"
+          } Catch {
+            $_ | Format-List -Property * -Force
+            Throw 'ERROR! See above!'
+          }


### PR DESCRIPTION
TODO:

- [ ] Define a workflow for updating a module group
- [ ] Call the update module group workflow from the update workflow - this should enable us to get 20 new workflows each with a cell for every module.
- [ ] Cleanup the `on` definition to only run `update` on tag