### PR TITLE
(MAINT) Remove local module import

### DIFF
--- a/.github/workflows/puppetize.yml
+++ b/.github/workflows/puppetize.yml
@@ -26,8 +26,6 @@ jobs:
         id: build-matrix
         run: |
           $VerbosePreference = 'Continue'
-          # Need to import from local to get fixes for search command until next release:
-          Import-Module .\src\Puppet.Dsc.psd1 -Verbose
           $SkipList = @(
             'DellBIOSProvider'                    # Cannot be built because some of the Resources are malformed/invalid PowerShell; source code not available to report bug
             'DellBIOSProviderX86'                 # Cannot be built because some of the Resources are malformed/invalid PowerShell; source code not available to report bug


### PR DESCRIPTION
Prior to this PR we were importing an unreleased version of Puppet.Dsc that had a fix for the search command. A new version of Puppet.Dsc has now been released that contains this fix.

This PR removes the local import from the Build Matrix step.