### PR TITLE
(MAINT) Add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/puppetize.yml
+++ b/.github/workflows/puppetize.yml
@@ -2,6 +2,7 @@ name: Puppetize
 on:
   schedule:
     - cron: "0 * * * *"
+  workflow_dispatch:
 
 defaults:
   run:


### PR DESCRIPTION
This PR adds the workflow_dispatch trigger. This will enable us to execute this workflow ad-hoc.

Issue #199 talks about what a workflow dispatch option could look like in the future.