### PR TITLE
Adding case insensitive enum values

### DIFF
--- a/src/internal/functions/Get-PuppetDataType.Tests.ps1
+++ b/src/internal/functions/Get-PuppetDataType.Tests.ps1
@@ -36,7 +36,7 @@ Describe 'Get-PuppetDataType' -Tag 'Unit' {
         Get-PuppetDataType -DscResourceProperty (New-DscParameter -PropertyType 'foo') | Should -BeExactly 'Optional[Hash]'
       }
       It 'Handles Enums' {
-        Get-PuppetDataType -DscResourceProperty (New-DscParameter -Values @('Foo', 'Bar', 'Baz')) | Should -BeExactly "Optional[Enum['Foo', 'Bar', 'Baz']]"
+        Get-PuppetDataType -DscResourceProperty (New-DscParameter -Values @('Foo', 'Bar', 'Baz')) | Should -BeExactly "Optional[Enum['Foo', 'Bar', 'Baz', 'foo', 'bar', 'baz']]"
       }
       It 'Handles well-known types' {
         Get-PuppetDataType -DscResourceProperty (New-DscParameter -PropertyType '[Bool]') | Should -BeExactly 'Optional[Boolean]'

--- a/src/internal/functions/Get-PuppetDataType.ps1
+++ b/src/internal/functions/Get-PuppetDataType.ps1
@@ -45,7 +45,8 @@ Function Get-PuppetDataType {
   If (![String]::IsNullOrEmpty($DscResourceProperty.Values)) {
     # Enums are handles specially
     $InnerText = $DscResourceProperty.Values | ForEach-Object -Process { "'$_'" }
-    $InnerText += $InnerText | ForEach-Object -Process {"$($_.toLower())" } | Select-Object -Unique
+    $InnerText += $InnerText | ForEach-Object -Process {"$($_.toLower())" }
+    $InnerText = $InnerText | Select-Object -Unique
     $PuppetDataTypeText = "Enum[$($InnerText -join ', ')]"
   } Else {
     If (Test-EmbeddedInstance -PropertyType $DscResourceProperty.PropertyType) {

--- a/src/internal/functions/Get-PuppetDataType.ps1
+++ b/src/internal/functions/Get-PuppetDataType.ps1
@@ -45,6 +45,7 @@ Function Get-PuppetDataType {
   If (![String]::IsNullOrEmpty($DscResourceProperty.Values)) {
     # Enums are handles specially
     $InnerText = $DscResourceProperty.Values | ForEach-Object -Process { "'$_'" }
+    $InnerText += $InnerText | ForEach-Object -Process {"$($_.toLower())" } | Select-Object -Unique
     $PuppetDataTypeText = "Enum[$($InnerText -join ', ')]"
   } Else {
     If (Test-EmbeddedInstance -PropertyType $DscResourceProperty.PropertyType) {


### PR DESCRIPTION
This change more closely mimics the functionality of [the original `dsc` module](https://forge.puppet.com/modules/puppetlabs/dsc), allowing enum values to be passed either as specified in the schema or their lowercase variants. 

Resolves Issue #216 