### PR TITLE
(CONT-257) Add PDKTemplateRef parameter

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2016, windows-2019]
+        os: [windows-2019, windows-2022]
         tag: [General, Unit]
         include:
           - tag: General
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2016, windows-2019]
+        os: [windows-2019, windows-2022]
         tag: [Basic, MultiModule]
         pwshlib_source: [forge, git]
         include:

--- a/src/functions/New-PuppetDscModule.ps1
+++ b/src/functions/New-PuppetDscModule.ps1
@@ -41,6 +41,8 @@ Function New-PuppetDscModule {
     .PARAMETER Repository
       Specifies a non-default PSRepository.
       If left blank, will default to PSGallery.
+    .PARAMETER PDKTemplateRef
+      Specifies the template git branch or tag to use when creating new moudles or classes.
     .EXAMPLE
       New-PuppetDscModule -PowerShellModuleName PowerShellGet -PowerShellModuleVersion 2.2.3 -Repository PSGallery
 
@@ -58,7 +60,8 @@ Function New-PuppetDscModule {
     [string]$OutputDirectory,
     [switch]$AllowPrerelease,
     [switch]$PassThru,
-    [string]$Repository
+    [string]$Repository,
+    [string]$PDKTemplateRef = '2.5.0'
   )
 
   Begin {
@@ -110,7 +113,7 @@ Function New-PuppetDscModule {
         $ErrorActionPreference = 'Stop'
         # Scaffold the module via the PDK
         Write-PSFMessage -Message 'Initializing the Puppet Module'
-        Initialize-PuppetModule -OutputFolderPath $OutputDirectory -PuppetModuleName $PuppetModuleName -verbose
+        Initialize-PuppetModule -OutputFolderPath $OutputDirectory -PuppetModuleName $PuppetModuleName -PDKTemplateRef $PDKTemplateRef -verbose
 
         # Vendor the PowerShell module and all of its dependencies
         Write-PSFMessage -Message 'Vendoring the DSC Resources'

--- a/src/internal/functions/Initialize-PuppetModule.ps1
+++ b/src/internal/functions/Initialize-PuppetModule.ps1
@@ -8,6 +8,8 @@ function Initialize-PuppetModule {
       The path, relative or literal, to the Puppet module's root folder.
     .PARAMETER PuppetModuleName
       The name of the Puppet module to create.
+    .PARAMETER PDKTemplateRef
+      Specifies the template git branch or tag to use when creating new moudles or classes.
     .PARAMETER Confirm
       Prompts for confirmation before overwriting the file
     .PARAMETER WhatIf
@@ -22,11 +24,17 @@ function Initialize-PuppetModule {
     [Parameter(Mandatory = $True)]
     [string]$OutputFolderPath,
     [Parameter(Mandatory = $True)]
-    [string]$PuppetModuleName
+    [string]$PuppetModuleName,
+    [Parameter(Mandatory = $False)]
+    [string]$PDKTemplateRef
   )
 
   begin {
     $Command = "pdk new module $PuppetModuleName --skip-interview --template-url https://github.com/puppetlabs/pdk-templates"
+    if ($PSBoundParameters.ContainsKey('PDKTemplateRef')) {
+      $Command = "$Command --template-ref $PDKTemplateRef"
+    }
+
     $ModuleFolderPath = Join-Path -Path $OutputFolderPath -ChildPath $PuppetModuleName
     $TemplateFolder = Join-Path -Path (Split-Path -Path $MyInvocation.MyCommand.Module.Path -Parent) -ChildPath 'internal/templates/static'
   }


### PR DESCRIPTION
Prior to this commit it was not possible to specify the version of pdk-templates that would be used when puppetizing a Dsc module.

PDK help sugegsts that the default ref is 2.5.0, however in practice it would pull down the latest tag from the pdk-templates repository. At the time of commit, this was 2.6.0.

The above diff causes some issues when puppetizing a resource due to gem incompatibilities.

This commit adds a new parameter called PDKTemplateRef to `New-PuppetDscModule` and `Initialize-PuppetModule` so that users can optionally provide a different pdk-templates version.

The default value has been set to 2.5.0.