### PR TITLE
(MAINT) Fix missing FORGE_TOKEN env

### DIFF
--- a/.github/workflows/puppetize.yml
+++ b/.github/workflows/puppetize.yml
@@ -84,6 +84,8 @@ jobs:
           }
 
       - name: "publish module"
+        env:
+          FORGE_TOKEN: ${{ secrets.FORGE_API_TOKEN }}
         run: |
           Import-Module -Name PSDesiredStateConfiguration -Force
           Import-Module -Name Puppet.Dsc -Force

--- a/.github/workflows/repuppetize.yml
+++ b/.github/workflows/repuppetize.yml
@@ -84,6 +84,8 @@ jobs:
           }
 
       - name: "update module"
+        env:
+          FORGE_TOKEN: ${{ secrets.FORGE_API_TOKEN }}
         run: |
           Import-Module -Name PSDesiredStateConfiguration -Force
           Import-Module -Name Puppet.Dsc -Force


### PR DESCRIPTION
Prior to this PR the FORGE_TOKEN environment variable was missing from the puppetize and repuppetize publish steps. This caused the workflow to fail.

This PR adds the env as required.