### PR TITLE
(GH-240) Fix incorrect enum generation

### DIFF
--- a/src/Puppet.Dsc/internal/functions/Get-PuppetDataType.Tests.ps1
+++ b/src/Puppet.Dsc/internal/functions/Get-PuppetDataType.Tests.ps1
@@ -36,7 +36,9 @@ Describe 'Get-PuppetDataType' -Tag 'Unit' {
         Get-PuppetDataType -DscResourceProperty (New-DscParameter -PropertyType 'foo') | Should -BeExactly 'Optional[Hash]'
       }
       It 'Handles Enums' {
-        Get-PuppetDataType -DscResourceProperty (New-DscParameter -Values @('Foo', 'Bar', 'Baz')) | Should -BeExactly "Optional[Enum['Foo', 'Bar', 'Baz', 'foo', 'bar', 'baz']]"
+        Get-PuppetDataType -DscResourceProperty (New-DscParameter -Values @('Foo', 'Bar', 'Baz')) | Should -BeExactly "Optional[Enum['Foo', 'foo', 'Bar', 'bar', 'Baz', 'baz']]"
+        Get-PuppetDataType -DscResourceProperty (New-DscParameter -Values @('Yes')) | Should -BeExactly "Optional[Enum['Yes', 'yes']]"
+        Get-PuppetDataType -DscResourceProperty (New-DscParameter -Values @('No')) | Should -BeExactly "Optional[Enum['No', 'no']]"
       }
       It 'Handles well-known types' {
         Get-PuppetDataType -DscResourceProperty (New-DscParameter -PropertyType '[Bool]') | Should -BeExactly 'Optional[Boolean]'

--- a/src/Puppet.Dsc/internal/functions/Get-PuppetDataType.ps1
+++ b/src/Puppet.Dsc/internal/functions/Get-PuppetDataType.ps1
@@ -44,10 +44,12 @@ Function Get-PuppetDataType {
   )
   If (![String]::IsNullOrEmpty($DscResourceProperty.Values)) {
     # Enums are handles specially
-    $InnerText = $DscResourceProperty.Values | ForEach-Object -Process { "'$_'" }
-    $InnerText += $InnerText | ForEach-Object -Process {"$($_.toLower())" }
-    $InnerText = $InnerText | Select-Object -Unique
-    $PuppetDataTypeText = "Enum[$($InnerText -join ', ')]"
+    $InnerText = [System.Collections.ArrayList]::new()
+    $DscResourceProperty.Values | ForEach-Object -Process {
+        $null = $InnerText.Add("'$_'")
+        $null = $innerText.Add("'$($_.toLower())'")
+    }
+    $PuppetDataTypeText = "Enum[$(($InnerText | Select-Object -Unique) -join ', ')]"
   } Else {
     If (Test-EmbeddedInstance -PropertyType $DscResourceProperty.PropertyType) {
       # TODO: We SHOULD be able to walk our way to the nested data structure for these Hashes


### PR DESCRIPTION
Prior to this change enums with a single value would be generated with a lowercase counterpart but the enum definition was malformed.

For example, given the the value `Yes` the following enum would be generated:

`Optional[Enum['Yes' 'yes]]`

This was happening because when a PowerShell array has a single value it will output a string.

This meant that when being assigned the lowercase variant of the value a string concatination occured causing the join on the next line to be ineffective.

This change updates the flow to use a `System.Collections.ArrayList` so that we will always have the expected datastructure.

After this change, given the value `Yes' the following enum would be generated:

`Optional[Enum['Yes', 'yes]]`

This is expected syntax and does not cause Puppets syntax parser to raise an error.