### PR TITLE
(CONT-1152) Use pdk templates ref 3.0.0

### DIFF
--- a/.github/workflows/puppetize.yml
+++ b/.github/workflows/puppetize.yml
@@ -9,7 +9,7 @@ on:
         required: false
 
 env:
-  pdk_version: 2.5.0.0
+  pdk_version: 2.7.1.0
   module_cache: Puppet.Dsc, PSFramework, PSDscResources, powershell-yaml
 
 jobs:

--- a/src/Puppet.Dsc/functions/New-PuppetDscModule.ps1
+++ b/src/Puppet.Dsc/functions/New-PuppetDscModule.ps1
@@ -61,7 +61,7 @@ Function New-PuppetDscModule {
     [switch]$AllowPrerelease,
     [switch]$PassThru,
     [string]$Repository,
-    [string]$PDKTemplateRef = '2.7.1'
+    [string]$PDKTemplateRef = '3.0.0'
   )
 
   Begin {

--- a/src/Puppet.Dsc/functions/New-PuppetDscModule.ps1
+++ b/src/Puppet.Dsc/functions/New-PuppetDscModule.ps1
@@ -61,7 +61,7 @@ Function New-PuppetDscModule {
     [switch]$AllowPrerelease,
     [switch]$PassThru,
     [string]$Repository,
-    [string]$PDKTemplateRef = '2.5.0'
+    [string]$PDKTemplateRef = '2.7.1'
   )
 
   Begin {


### PR DESCRIPTION
Use pdk templates ref 3.0.0 instead of 2.5.0 as the puppetise workflow seems to have a problem with the `pdk new module` command
