### PR TITLE
(CAT-1322) - Run puppetize biweekly on top 50 DSC Modules

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,11 +1,7 @@
-name: CI
+name: nightly
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+  schedule:
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 env:

--- a/.github/workflows/puppetize.yml
+++ b/.github/workflows/puppetize.yml
@@ -36,10 +36,21 @@ jobs:
         run: |
           Import-Module -Name PSDesiredStateConfiguration -Force
           Import-Module -Name ./src/BuildMatrix/BuildMatrix.psd1 -Force
+          $response = Invoke-WebRequest -URI https://forgeapi.puppet.com/v3/modules?owner=dsc`&limit=50 -Method Get -UseBasicParsing
+          $parsed = $response.Content | ConvertFrom-Json
+          $fileName = "./dsc_resources.yml"
+
+          ForEach ($Module in $parsed.results.name) {
+            $module_name_exists =  Select-String -Quiet -Pattern $Module -Path $fileName
+            if (-not $module_name_exists)
+            {
+              Add-Content -Path $fileName -Value "  - name: $Module"
+            }
+          }
 
           $ModuleData = $ENV:MODULE_NAME
           if (!$ModuleData) {
-            $ModuleData = Get-ModuleData -Path ./dsc_resources.yml -UnPuppetizedOnly
+            $ModuleData = Get-ModuleData -Path $fileName -UnPuppetizedOnly
           }
 
           $ModuleData | ConvertTo-BuildMatrix | Set-BuildMatrix

--- a/.github/workflows/puppetize.yml
+++ b/.github/workflows/puppetize.yml
@@ -1,6 +1,8 @@
 name: "puppetize"
 
 on:
+  schedule:
+    - cron: "0 6 1,15 * *" 
   workflow_dispatch:
     inputs:
       module_name:

--- a/.github/workflows/puppetize.yml
+++ b/.github/workflows/puppetize.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           Import-Module -Name PSDesiredStateConfiguration -Force
           Import-Module -Name ./src/BuildMatrix/BuildMatrix.psd1 -Force
-          $response = Invoke-WebRequest -URI https://forgeapi.puppet.com/v3/modules?owner=dsc`&limit=50 -Method Get -UseBasicParsing
+          $response = Invoke-WebRequest -URI https://forgeapi.puppet.com/v3/modules?owner=dsc`&limit=50`&endorsements=approved`&sort_by=downloads -Method Get -UseBasicParsing
           $parsed = $response.Content | ConvertFrom-Json
           $fileName = "./dsc_resources.yml"
 

--- a/.github/workflows/repuppetize.yml
+++ b/.github/workflows/repuppetize.yml
@@ -37,10 +37,11 @@ jobs:
         run: |
           Import-Module -Name PSDesiredStateConfiguration -Force
           Import-Module -Name ./src/BuildMatrix/BuildMatrix.psd1 -Force
+          $fileName = "./dsc_resources.yml"
 
           $ModuleData = $ENV:MODULE_NAME
           if (!$ModuleData) {
-            $ModuleData = Get-ModuleData -Path ./dsc_resources.yml -PuppetizedOnly
+            $ModuleData = Get-ModuleData -Path $fileName -PuppetizedOnly
           }
 
           $ModuleData | ConvertTo-BuildMatrix | Set-BuildMatrix

--- a/dsc_resources.yml
+++ b/dsc_resources.yml
@@ -1,4 +1,5 @@
 resources:
+  - name: 7ZipArchiveDsc
   - name: ActiveDirectoryDsc
   - name: AuditPolicyDsc
   - name: CertificateDsc

--- a/src/Puppet.Dsc/functions/New-PuppetDscModule.ps1
+++ b/src/Puppet.Dsc/functions/New-PuppetDscModule.ps1
@@ -169,7 +169,7 @@ Function New-PuppetDscModule {
         # Generate REFERENCE.md file for the Puppet module from the auto-generated types for each DSC resource
         Write-PSFMessage -Message 'Writing the reference documentation for the Puppet module'
         Set-PSModulePath -Path $InitialPsModulePath
-        Install-Gems -PuppetModuleFolderPath $PuppetModuleRootFolderDirectory -Verbose
+        Invoke-BundleInstall -PuppetModuleFolderPath $PuppetModuleRootFolderDirectory -Verbose
         Add-PuppetReferenceDocumentation -PuppetModuleFolderPath $PuppetModuleRootFolderDirectory -Verbose
 
         If ($PassThru) {

--- a/src/Puppet.Dsc/internal/functions/Install-Gems.ps1
+++ b/src/Puppet.Dsc/internal/functions/Install-Gems.ps1
@@ -1,4 +1,4 @@
-function Install-Gems {
+function Invoke-BundleInstall {
   <#
       .SYNOPSIS
         Install required gems


### PR DESCRIPTION
## Summary
This PR changes the puppetize workflow to run at 6am on the 1st and 15th day of each month.
It also includes a change which allows the workflow to gather the top 50 DSC modules using the forge API, and puppetize them. 

**Note** 
This only creates a job for the modules which are out of sync with the PS Gallery, not all modules will create a job so this will keep compute resources down.

This PR also contains a number of smaller maintenance fixes:

- Updated the naming of the `Install-Gems` function to `Invoke-BundleInstall` as per the powershell styling guidelines.
- Adds a nightly workflow for reporting
- Adds `7ZipArchiveDsc` to dsc_resources.yml as the forge name does not match the name found for this module on PSGallery.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
