### PR TITLE
(CAT-1322) - Rename Install-Gems to Invoke-BundleInstall & Run Puppetize Biweekly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,8 @@ jobs:
 
       - name: "test"
         run: |
+          Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
+          refreshenv
           Import-Module -Name PSDesiredStateConfiguration -Force
           Import-Module -Name .\src\Puppet.Dsc\puppet.dsc.psd1 -Force
           $null = Get-Command -Module Puppet.Dsc

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -110,6 +110,8 @@ jobs:
 
       - name: "test"
         run: |
+          Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
+          refreshenv
           Import-Module -Name PSDesiredStateConfiguration -Force
           Import-Module -Name .\src\Puppet.Dsc\puppet.dsc.psd1 -Force
           $null = Get-Command -Module Puppet.Dsc

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,11 +1,7 @@
-name: CI
+name: nightly
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+  schedule:
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 env:

--- a/.github/workflows/puppetize.yml
+++ b/.github/workflows/puppetize.yml
@@ -38,22 +38,24 @@ jobs:
         run: |
           Import-Module -Name PSDesiredStateConfiguration -Force
           Import-Module -Name ./src/BuildMatrix/BuildMatrix.psd1 -Force
-          # Get the top 50 downloaded DSC modules from the forge
-          $response = Invoke-WebRequest -URI https://forgeapi.puppet.com/v3/modules?owner=dsc`&limit=50`&endorsements=approved`&sort_by=downloads -Method Get -UseBasicParsing
-          $parsed = $response.Content | ConvertFrom-Json
-          $fileName = "./dsc_resources.yml"
-
-          # Add the module to the dsc_resource.yml if it doesn't exist
-          ForEach ($Module in $parsed.results.name) {
-            $module_name_exists =  Select-String -Quiet -Pattern $Module -Path $fileName
-            if (-not $module_name_exists)
-            {
-              Add-Content -Path $fileName -Value "  - name: $Module"
-            }
-          }
 
           $ModuleData = $ENV:MODULE_NAME
+          # if no module name is provided to the workflow, get the top 50 downloaded DSC modules from the forge
           if (!$ModuleData) {
+            # Get the top 50 downloaded DSC modules from the forge
+            $response = Invoke-WebRequest -URI https://forgeapi.puppet.com/v3/modules?owner=dsc`&limit=50`&endorsements=approved`&sort_by=downloads -Method Get -UseBasicParsing
+            $parsed = $response.Content | ConvertFrom-Json
+            $fileName = "./dsc_resources.yml"
+  
+            # Add the module to the dsc_resource.yml if it doesn't exist
+            ForEach ($Module in $parsed.results.name) {
+              $module_name_exists =  Select-String -Quiet -Pattern $Module -Path $fileName
+              if (-not $module_name_exists)
+              {
+                Add-Content -Path $fileName -Value "  - name: $Module"
+              }
+            }
+  
             $ModuleData = Get-ModuleData -Path $fileName -UnPuppetizedOnly
           }
 

--- a/.github/workflows/puppetize.yml
+++ b/.github/workflows/puppetize.yml
@@ -1,6 +1,8 @@
 name: "puppetize"
 
 on:
+  schedule:
+    - cron: "0 6 1,15 * *" 
   workflow_dispatch:
     inputs:
       module_name:
@@ -9,7 +11,7 @@ on:
         required: false
 
 env:
-  pdk_version: 3.0.0.0
+  pdk_version: 2.7.1.0
   module_cache: Puppet.Dsc, PSFramework, PSDscResources, powershell-yaml
 
 jobs:
@@ -36,10 +38,23 @@ jobs:
         run: |
           Import-Module -Name PSDesiredStateConfiguration -Force
           Import-Module -Name ./src/BuildMatrix/BuildMatrix.psd1 -Force
+          # Get the top 50 downloaded DSC modules from the forge
+          $response = Invoke-WebRequest -URI https://forgeapi.puppet.com/v3/modules?owner=dsc`&limit=50`&endorsements=approved`&sort_by=downloads -Method Get -UseBasicParsing
+          $parsed = $response.Content | ConvertFrom-Json
+          $fileName = "./dsc_resources.yml"
+
+          # Add the module to the dsc_resource.yml if it doesn't exist
+          ForEach ($Module in $parsed.results.name) {
+            $module_name_exists =  Select-String -Quiet -Pattern $Module -Path $fileName
+            if (-not $module_name_exists)
+            {
+              Add-Content -Path $fileName -Value "  - name: $Module"
+            }
+          }
 
           $ModuleData = $ENV:MODULE_NAME
           if (!$ModuleData) {
-            $ModuleData = Get-ModuleData -Path ./dsc_resources.yml -UnPuppetizedOnly
+            $ModuleData = Get-ModuleData -Path $fileName -UnPuppetizedOnly
           }
 
           $ModuleData | ConvertTo-BuildMatrix | Set-BuildMatrix
@@ -87,15 +102,13 @@ jobs:
         env:
           FORGE_TOKEN: ${{ secrets.FORGE_API_TOKEN }}
         run: |
-          Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
-          refreshenv
           Import-Module -Name PSDesiredStateConfiguration -Force
-          Import-Module -Name ./src/Puppet.Dsc -Force
+          Import-Module -Name Puppet.Dsc -Force
           $null = Get-Command PDK, Publish-NewDscModuleVersion
 
           $PublishParameters = @{
             ForgeNameSpace = 'dsc'
-            Name = '${{ matrix.module }}'
+            Name = '${{ matrix.module_name }}'
             OnlyNewer = $true
             MaxBuildCount = 1
           }

--- a/.github/workflows/puppetize.yml
+++ b/.github/workflows/puppetize.yml
@@ -11,7 +11,7 @@ on:
         required: false
 
 env:
-  pdk_version: 2.7.1.0
+  pdk_version: 3.0.0.0
   module_cache: Puppet.Dsc, PSFramework, PSDscResources, powershell-yaml
 
 jobs:

--- a/.github/workflows/puppetize.yml
+++ b/.github/workflows/puppetize.yml
@@ -102,13 +102,15 @@ jobs:
         env:
           FORGE_TOKEN: ${{ secrets.FORGE_API_TOKEN }}
         run: |
+          Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
+          refreshenv
           Import-Module -Name PSDesiredStateConfiguration -Force
           Import-Module -Name Puppet.Dsc -Force
           $null = Get-Command PDK, Publish-NewDscModuleVersion
 
           $PublishParameters = @{
             ForgeNameSpace = 'dsc'
-            Name = '${{ matrix.module_name }}'
+            Name = '${{ matrix.module }}'
             OnlyNewer = $true
             MaxBuildCount = 1
           }

--- a/.github/workflows/repuppetize.yml
+++ b/.github/workflows/repuppetize.yml
@@ -88,6 +88,8 @@ jobs:
         env:
           FORGE_TOKEN: ${{ secrets.FORGE_API_TOKEN }}
         run: |
+          Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
+          refreshenv
           Import-Module -Name PSDesiredStateConfiguration -Force
           Import-Module -Name Puppet.Dsc -Force
           $null = Get-Command PDK, Publish-NewDscModuleVersion

--- a/dsc_resources.yml
+++ b/dsc_resources.yml
@@ -19,6 +19,14 @@ resources:
   - name: UpdateServicesDsc
   - name: xCredSSP
   - name: xExchange
+  - name: xHyper-V
   - name: xPSDesiredStateConfiguration
   - name: WebAdministrationDsc
   - name: WSManDsc
+
+# the below modules will need to remain with in this file, commented out, as there is a mismatch between their naming on the forge and PS Gallery.
+# their names, as they appear on PSGallery, are added to the default list above.
+# a7ziparchivedsc
+# xhyper_v
+# xphp (this module is broke upstream and will not be included in the default list see https://github.com/dsccommunity/xPhp/issues/13. 
+# Its worth noting that the latest version is already on the forge, and that it is also no longer maintained.)

--- a/dsc_resources.yml
+++ b/dsc_resources.yml
@@ -1,4 +1,5 @@
 resources:
+  - name: 7ZipArchiveDsc
   - name: ActiveDirectoryDsc
   - name: AuditPolicyDsc
   - name: CertificateDsc

--- a/src/Puppet.Dsc/functions/New-PuppetDscModule.Tests.ps1
+++ b/src/Puppet.Dsc/functions/New-PuppetDscModule.Tests.ps1
@@ -40,6 +40,7 @@ Describe 'New-PuppetDscModule' -Tag 'Unit' {
         }
         Mock Test-Path { $true }
         Mock Out-Utf8File {}
+        Mock Invoke-BundleInstall {}
         Mock Add-PuppetReferenceDocumentation {}
         Mock Get-Item {}
 

--- a/src/Puppet.Dsc/functions/New-PuppetDscModule.ps1
+++ b/src/Puppet.Dsc/functions/New-PuppetDscModule.ps1
@@ -169,7 +169,7 @@ Function New-PuppetDscModule {
         # Generate REFERENCE.md file for the Puppet module from the auto-generated types for each DSC resource
         Write-PSFMessage -Message 'Writing the reference documentation for the Puppet module'
         Set-PSModulePath -Path $InitialPsModulePath
-        Install-Gems -PuppetModuleFolderPath $PuppetModuleRootFolderDirectory -Verbose
+        Invoke-BundleInstall -PuppetModuleFolderPath $PuppetModuleRootFolderDirectory -Verbose
         Add-PuppetReferenceDocumentation -PuppetModuleFolderPath $PuppetModuleRootFolderDirectory -Verbose
 
         If ($PassThru) {

--- a/src/Puppet.Dsc/internal/functions/Invoke-BundleInstall.ps1
+++ b/src/Puppet.Dsc/internal/functions/Invoke-BundleInstall.ps1
@@ -21,7 +21,7 @@ function Invoke-BundleInstall {
     Try {
       $ErrorActionPreference = 'Stop'
       Invoke-PdkCommand -Path $PuppetModuleFolderPath -Command $Command -SuccessFilterScript {
-        $_ -match 'gems now installed'
+        $_ -match 'Bundle complete!'
       }
     } Catch {
       $PSCmdlet.ThrowTerminatingError($PSItem)

--- a/src/Puppet.Dsc/internal/functions/Invoke-BundleInstall.ps1
+++ b/src/Puppet.Dsc/internal/functions/Invoke-BundleInstall.ps1
@@ -1,4 +1,4 @@
-function Install-Gems {
+function Invoke-BundleInstall {
   <#
       .SYNOPSIS
         Install required gems


### PR DESCRIPTION
### Summary
This PR changes the puppetize workflow to run at 6am on the 1st and 15th day of each month.
It also includes a change which allows the workflow to gather the top 50 downloaded DSC modules using the forge API, and puppetize them.

### Note
This only creates a job for the modules which are out of sync with the PS Gallery, not all modules will create a job so this will keep compute resources down.

This PR also contains a number of smaller maintenance fixes:

Updated the naming of the Install-Gems function to Invoke-BundleInstall as per the powershell styling guidelines.
Adds a nightly workflow for reporting
Adds 7ZipArchiveDsc to dsc_resources.yml as the forge name does not match the name found for this module on PSGallery, so prevents a mismatch between the forge and psgallery apis.

### Checklist
 🟢 Spec tests.
 🟢 Acceptance tests.
 Manually verified.