### PR TITLE
(CAT-1484) - Add ensurable property to resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 import
 .vagrant/
 *Results.xml
-docs/*
+!docs/architecture
 !docs/about_*
 Puppet.Dsc/
 !src/Puppet.Dsc/

--- a/docs/architecture/decisions/0001-force-ensurable.md
+++ b/docs/architecture/decisions/0001-force-ensurable.md
@@ -1,0 +1,50 @@
+# 1. Force Ensurable = false on Non-ensurable resources
+
+Date: 2023-11-07
+
+## Status
+
+Accepted
+
+## Context
+
+In CAT-1484, it was found that there was a mismatch in behaviour between dsc resource keys and puppet namevars. It was widely assumed that these two attribute types eseentially behaved the same, which was found not to be the case with the dsc_virtualmemory resource (and others) in the ComputerManagementDsc module.
+Puppet uses namevars as identifiers, so when a manifest is passed containing only namevar attributes, puppet will ignore the updating values in a manifest and not attempt to update the resource, However, DSC will update the dsc resource when only key attributes as passed.
+
+So although they appear the same on the surface, it was found that the below manifest and .mof file **would not** produce the same outcome on the target machine.
+
+```puppet
+dsc_virtualmemory { 'CDrive':
+    dsc_drive => 'C', # namevar
+    dsc_type  => 'AutoManagePagingFile', #namevar
+}
+```
+
+```powershell
+Configuration VirtualMemory_SetVirtualMemory_Config
+{
+    Import-DSCResource -ModuleName ComputerManagementDsc
+
+    Node localhost
+    {
+        VirtualMemory PagingSettings
+        {
+            Type        = 'AutoManagePagingFile' #Key
+            Drive       = 'C' #Key
+        }
+    }
+}
+```
+
+Although the content of both files are essentially equal, the DSC resource will apply the specified changes, puppet will not.
+
+## Decision
+
+We have decided to force an ensurable property on every DSC resource type that has no ensure parameter already present. This has a couple of benefits:
+
+1. Now documentation will clearly show that ensurable can only be set to false on certain types i.e. that they are not ensurabled by puppet.
+2. The default value of false ensures that this is always passed along side namevar only manifests, preventing puppet from DSC key attribute updates like above.
+
+## Consequences
+
+Each initial puppet run after this change is applied will show as creating/updating of a resource. This will only occur on the first run and not any subsequent, true to the nature of Puppet.

--- a/src/Puppet.Dsc/internal/functions/Get-TypeContent.ps1
+++ b/src/Puppet.Dsc/internal/functions/Get-TypeContent.ps1
@@ -41,7 +41,7 @@ function Get-TypeContent {
       $NotEnsurable = [pscustomobject]@{
         Name              = 'ensurable'
         DefaultValue      = 'false'
-        Type              = "Enum['False', 'false']"
+        Type              = "Boolean['false']"
         Help              = 'Default attribute added to all dsc types without an ensure property. This resource is not ensurable.'
         mandatory_for_get = 'false'
         mandatory_for_set = 'false'

--- a/src/Puppet.Dsc/internal/functions/Get-TypeContent.ps1
+++ b/src/Puppet.Dsc/internal/functions/Get-TypeContent.ps1
@@ -36,6 +36,24 @@ function Get-TypeContent {
       } Else {
         $FriendlyName = $Resource.FriendlyName
       }
+      # We add an ensurable property to all DSC resources that don't have an ensure property
+      $ResourceIsEnsurable = ($Resource.ParameterInfo | Select-Object -ExpandProperty Name).Contains('ensure')
+      $NotEnsurable = [pscustomobject]@{
+        Name              = 'ensurable'
+        DefaultValue      = 'false'
+        Type              = "Enum['False', 'false']"
+        Help              = 'Default attribute added to all dsc types without an ensure property. This resource is not ensurable.'
+        mandatory_for_get = 'false'
+        mandatory_for_set = 'false'
+        is_parameter      = 'false'
+        is_namevar        = 'false'
+        mof_is_embedded   = 'false'
+        mof_type          = 'String'
+      }
+      # We only add the ensurable property if it's not already present
+      If (!$ResourceIsEnsurable) {
+        $Resource.ParameterInfo += $NotEnsurable
+      }
       # It is not *currently* possible to reliably programmatically retrieve
       # the description information for a DSC Resource via CIM instances or
       # Get-DscResource or Get-Help.

--- a/src/Puppet.Dsc/internal/functions/Get-TypeContent.ps1
+++ b/src/Puppet.Dsc/internal/functions/Get-TypeContent.ps1
@@ -41,7 +41,7 @@ function Get-TypeContent {
       $NotEnsurable = [pscustomobject]@{
         Name              = 'ensurable'
         DefaultValue      = 'false'
-        Type              = "Boolean['false']"
+        Type              = 'Boolean[false]'
         Help              = 'Default attribute added to all dsc types without an ensure property. This resource is not ensurable.'
         mandatory_for_get = 'false'
         mandatory_for_set = 'false'

--- a/src/Puppet.Dsc/internal/functions/Get-TypeParameterContent.ps1
+++ b/src/Puppet.Dsc/internal/functions/Get-TypeParameterContent.ps1
@@ -39,10 +39,10 @@ $(
     # Assemble the Description String with appropriate indentation
     "      desc: $(ConvertTo-PuppetRubyString -String ($Parameter.Help.Split("`n") -Join ' ')),"
   }
-    If (![string]::IsNullOrEmpty($Parameter.DefaultValue)) {
-    "      default: $($Parameter.DefaultValue),"
-  }
 )
+$(    If (![string]::IsNullOrEmpty($Parameter.DefaultValue)) {
+    "      default: $($Parameter.DefaultValue),"
+})
 $(
   $Behaviours = @()
   If ($Parameter.is_namevar -eq 'true') { $Behaviours += ':namevar' }

--- a/src/Puppet.Dsc/internal/functions/Get-TypeParameterContent.ps1
+++ b/src/Puppet.Dsc/internal/functions/Get-TypeParameterContent.ps1
@@ -39,6 +39,9 @@ $(
     # Assemble the Description String with appropriate indentation
     "      desc: $(ConvertTo-PuppetRubyString -String ($Parameter.Help.Split("`n") -Join ' ')),"
   }
+    If (![string]::IsNullOrEmpty($Parameter.DefaultValue)) {
+    "      default: $($Parameter.DefaultValue),"
+  }
 )
 $(
   $Behaviours = @()

--- a/src/Puppet.Dsc/internal/functions/Get-TypeParameterContent.ps1
+++ b/src/Puppet.Dsc/internal/functions/Get-TypeParameterContent.ps1
@@ -24,8 +24,11 @@ Function Get-TypeParameterContent {
 
   ForEach ($Parameter in $ParameterInfo) {
     if (![string]::IsNullOrEmpty($Parameter.name)) {
+      if ($Parameter.name -ne 'ensurable') {
+        $Parameter.name = "dsc_$($Parameter.name)"
+      }
       New-Object -TypeName System.String @"
-    dsc_$($Parameter.name): {
+    $($Parameter.name): {
       type: $(ConvertTo-PuppetRubyString -String ($Parameter.Type -split "`n" -join "`n            ")),
 $(
   If ([string]::IsNullOrEmpty($Parameter.Help)) {


### PR DESCRIPTION
## Summary

This PR adds a `ensurable` property to each resource which does not already have an ensure property defined. This has a couple of beneifts:

1. Prevents issues as seen in CAT-1484, where puppet namevars and DSC keys differences arise. By default, puppet will ignore namevar changes if they are the only atrtibutes passed in a manifest. This is a design of puppet and makes sure as namevars should only identify a resource. DSC's key values behave differently to this.
2. Will now clearly show in docs that the resource CANNOT be ensured.

The property sets a default of 'false' and will only accept a value of 'false'. The value will not need to be specified in manifests.

## Additional Context
Puppet will not update a resource if only namevars are passed. We can see in the puppet source code that there is no logic to run the `sync_if_needed` method on namevars only. https://github.com/puppetlabs/puppet/blob/e20659bad696e388e48444f38bac5ba1334d2799/lib/puppet/transaction/resource_harness.rb#L73
Which makes sense as these are meant solely to be identifiers.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
