### PR TITLE
(maint) - Remove Puppet.Dsc from module cache

### DIFF
--- a/.github/workflows/puppetize.yml
+++ b/.github/workflows/puppetize.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   pdk_version: 2.7.1.0
-  module_cache: Puppet.Dsc, PSFramework, PSDscResources, powershell-yaml
+  module_cache: PSFramework, PSDscResources, powershell-yaml
 
 jobs:
   setup:
@@ -36,6 +36,7 @@ jobs:
         id: "setup_matrix"
         shell: powershell
         run: |
+          Import-Module -Name .\src\Puppet.Dsc\puppet.dsc.psd1 -Force
           Import-Module -Name PSDesiredStateConfiguration -Force
           Import-Module -Name ./src/BuildMatrix/BuildMatrix.psd1 -Force
 
@@ -107,7 +108,7 @@ jobs:
           Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
           refreshenv
           Import-Module -Name PSDesiredStateConfiguration -Force
-          Import-Module -Name Puppet.Dsc -Force
+          Import-Module -Name .\src\Puppet.Dsc\puppet.dsc.psd1 -Force
           $null = Get-Command PDK, Publish-NewDscModuleVersion
 
           $PublishParameters = @{

--- a/.github/workflows/repuppetize.yml
+++ b/.github/workflows/repuppetize.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   pdk_version: 2.7.1.0
-  module_cache: Puppet.Dsc, PSFramework, PSDscResources, powershell-yaml
+  module_cache: PSFramework, PSDscResources, powershell-yaml
 
 jobs:
   setup:
@@ -35,6 +35,7 @@ jobs:
         id: "setup_matrix"
         shell: powershell
         run: |
+          Import-Module -Name .\src\Puppet.Dsc\puppet.dsc.psd1 -Force
           Import-Module -Name PSDesiredStateConfiguration -Force
           Import-Module -Name ./src/BuildMatrix/BuildMatrix.psd1 -Force
 
@@ -91,7 +92,7 @@ jobs:
           Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
           refreshenv
           Import-Module -Name PSDesiredStateConfiguration -Force
-          Import-Module -Name Puppet.Dsc -Force
+          Import-Module -Name .\src\Puppet.Dsc\puppet.dsc.psd1 -Force
           $null = Get-Command PDK, Publish-NewDscModuleVersion
 
           $UpdateForgeDscModule = @{


### PR DESCRIPTION
## Summary
We shouldn't cache the Puppet.Dsc module itself as we run the risk of using an outdated version of the module when puppetizing/repuppetizing.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
