### PR TITLE
bump required pwshlib to 1.2.0 and greater

### DIFF
--- a/src/Puppet.Dsc/internal/functions/Update-PuppetModuleMetadata.Tests.ps1
+++ b/src/Puppet.Dsc/internal/functions/Update-PuppetModuleMetadata.Tests.ps1
@@ -85,7 +85,7 @@ Describe 'Update-PuppetModuleMetadata' -Tag 'Unit' {
         }
         It 'Updates the dependencies' {
           $Result.dependencies[0].Name | Should -Be 'puppetlabs/pwshlib'
-          $Result.dependencies[0].version_requirement | Should -Be '>= 0.9.0 < 2.0.0'
+          $Result.dependencies[0].version_requirement | Should -Be '>= 1.2.0 < 2.0.0'
         }
         It 'Updates the supported operating system list' {
           $Result.operatingsystem_support[0].operatingsystem | Should -Be 'windows'

--- a/src/Puppet.Dsc/internal/functions/Update-PuppetModuleMetadata.ps1
+++ b/src/Puppet.Dsc/internal/functions/Update-PuppetModuleMetadata.ps1
@@ -78,7 +78,7 @@ function Update-PuppetModuleMetadata {
     $PuppetMetadata.dependencies = @(
       @{
         name                = 'puppetlabs/pwshlib'
-        version_requirement = '>= 0.9.0 < 2.0.0'
+        version_requirement = '>= 1.2.0 < 2.0.0'
       }
     )
     # Update the operating sytem to only support windows *for now*.


### PR DESCRIPTION
bumps the minimum required puppetlabs/pwshlib to 1.2.0, as dsc_timeout logic is only present in these module versions.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
