### PR TITLE
(maint) - fix broken nightlies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,10 @@ jobs:
 
     steps:
       - name: "checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "install modules"
-        uses: potatoqualitee/psmodulecache@v5.1
+        uses: potatoqualitee/psmodulecache@v6.2.1
         with:
           shell: powershell
           modules-to-cache: ${{ env.module_cache }}
@@ -53,7 +53,7 @@ jobs:
           matrix.os == 'windows-2022' && 
           matrix.tag == 'Unit' && 
           env.CODECOV_TOKEN != ''
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
@@ -81,10 +81,10 @@ jobs:
 
     steps:
       - name: "checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "install modules"
-        uses: potatoqualitee/psmodulecache@v5.1
+        uses: potatoqualitee/psmodulecache@v6.2.1
         with:
           shell: powershell
           modules-to-cache: ${{ env.module_cache }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: "checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "install modules"
-        uses: potatoqualitee/psmodulecache@v5.1
+        uses: potatoqualitee/psmodulecache@v6.2.1
         with:
           shell: powershell
           modules-to-cache: ${{ env.module_cache }}
@@ -62,10 +62,10 @@ jobs:
 
     steps:
       - name: "checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "install modules"
-        uses: potatoqualitee/psmodulecache@v5.1
+        uses: potatoqualitee/psmodulecache@v6.2.1
         with:
           shell: powershell
           modules-to-cache: ${{ env.module_cache }}

--- a/.github/workflows/puppetize.yml
+++ b/.github/workflows/puppetize.yml
@@ -23,10 +23,10 @@ jobs:
     steps:
 
       - name: "checkout"
-        uses: "actions/checkout@v3"
+        uses: actions/checkout@v4
 
       - name: "install modules"
-        uses: potatoqualitee/psmodulecache@v5.1
+        uses: potatoqualitee/psmodulecache@v6.2.1
         with:
           shell: powershell
           modules-to-cache: ${{ env.module_cache }}
@@ -77,10 +77,10 @@ jobs:
     steps:
 
       - name: "checkout"
-        uses: "actions/checkout@v3"
+        uses: actions/checkout@v4
 
       - name: "install required modules"
-        uses: potatoqualitee/psmodulecache@v5.1
+        uses: potatoqualitee/psmodulecache@v6.2.1
         with:
           shell: powershell
           modules-to-cache: ${{ env.module_cache }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,14 +22,14 @@ jobs:
     steps:
 
       - name: "checkout"
-        uses: "actions/checkout@v3"
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.target }}
           clean: true
           fetch-depth: 0
 
       - name: "install modules"
-        uses: potatoqualitee/psmodulecache@v5.1
+        uses: potatoqualitee/psmodulecache@v6.2.1
         with:
           shell: powershell
           modules-to-cache: ${{ env.module_cache }}

--- a/.github/workflows/release_prep.yml
+++ b/.github/workflows/release_prep.yml
@@ -20,13 +20,13 @@ jobs:
     steps:
 
       - name: "checkout"
-        uses: "actions/checkout@v3"
+        uses: actions/checkout@v4
         with:
           clean: true
           fetch-depth: 0
 
       - name: "install modules"
-        uses: potatoqualitee/psmodulecache@v5.1
+        uses: potatoqualitee/psmodulecache@v6.2.1
         with:
           shell: powershell
           modules-to-cache: ${{ env.module_cache }}

--- a/.github/workflows/repuppetize.yml
+++ b/.github/workflows/repuppetize.yml
@@ -22,10 +22,10 @@ jobs:
     steps:
 
       - name: "checkout"
-        uses: "actions/checkout@v3"
+        uses: actions/checkout@v4
 
       - name: "install modules"
-        uses: potatoqualitee/psmodulecache@v5.1
+        uses: potatoqualitee/psmodulecache@v6.2.1
         with:
           shell: powershell
           modules-to-cache: ${{ env.module_cache }}
@@ -61,10 +61,10 @@ jobs:
     steps:
 
       - name: "checkout"
-        uses: "actions/checkout@v3"
+        uses: actions/checkout@v4
 
       - name: "install required modules"
-        uses: potatoqualitee/psmodulecache@v5.1
+        uses: potatoqualitee/psmodulecache@v6.2.1
         with:
           shell: powershell
           modules-to-cache: ${{ env.module_cache }}


### PR DESCRIPTION
Bumps potatoqualitee/psmodulecache to v6.2.1 to no longer pull in actions/cache v3
Bumps codecov/codecov-action to v5 to no longer pull in actions/cache v3
Bumps actions/checkout to latest v4