### PR TITLE
(CAT-2253) Remove CodeCov from the repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,6 @@ on:
 
 env:
   module_cache: PSFramework, PSDscResources, AccessControlDSC, powershell-yaml, PSScriptAnalyzer
-  COVERAGE_ENABLED: 'yes'
-  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
 defaults:
   run:
@@ -46,19 +44,6 @@ jobs:
 
       - name: Run Unit Tests
         uses: ./.github/actions/run-unit-tests
-
-      - name: Upload coverage reports to Codecov
-        # Only upload report once per CI run
-        if: |
-          matrix.os == 'windows-2022' && 
-          matrix.tag == 'Unit' && 
-          env.CODECOV_TOKEN != ''
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
-          fail_ci_if_error: true
-          verbose: true
 
   acceptance:
     runs-on: ${{ matrix.os }}

--- a/scripts/invoke_tests.ps1
+++ b/scripts/invoke_tests.ps1
@@ -44,12 +44,4 @@ If ($null -ne $PwshLibSource) {
   $PesterConfiguration.Run.Path = $TestPath
 }
 
-If ($Tag -eq 'Unit' -and 'yes' -eq $Env:COVERAGE_ENABLED){
-  $PesterConfiguration.CodeCoverage.Enabled = $true
-  $PesterConfiguration.CodeCoverage.Path = @(
-    Resolve-Path -Path "./src/Puppet.Dsc/internal/functions/*.ps1"
-    Resolve-Path -Path "./src/Puppet.Dsc/functions/*.ps1"
-  )
-}
-
 Invoke-Pester -Configuration $PesterConfiguration


### PR DESCRIPTION
Currently there are unexplained failures in when uploading the codecov report. It has more drawbacks at this point that advantages using, therefore removing CodeCov.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
