### PR TITLE
(CAT-2553) Investigate broken CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022]
+        os: [windows-2022, windows-latest]
         tag: [General, Unit]
         include:
           - tag: General
@@ -51,13 +51,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022]
+        os: [windows-2022, windows-latest]
         tag: [Basic]
         pwshlib_source: [forge, git]
         include:
           - pwshlib_source: forge
             pwshlib_repo: "puppetlabs/pwshlib"
-            pwshlib_ref: "latest" # Change to a specific version if desired
+            pwshlib_ref: "latest" # Track latest release
             results_file: Acceptance.Forge.Results.xml
           - pwshlib_source: git
             pwshlib_repo: "https://github.com/puppetlabs/ruby-pwsh.git" # Change to another fork if desired

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022]
+        os: [windows-2022, windows-latest]
         tag: [General, Unit]
         include:
           - tag: General
@@ -47,13 +47,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022]
+        os: [windows-2022, windows-latest]
         tag: [Basic]
         pwshlib_source: [forge, git]
         include:
           - pwshlib_source: forge
             pwshlib_repo: "puppetlabs/pwshlib"
-            pwshlib_ref: "latest" # Change to a specific version if desired
+            pwshlib_ref: "latest" # Track latest release
             results_file: Acceptance.Forge.Results.xml
           - pwshlib_source: git
             pwshlib_repo: "https://github.com/puppetlabs/ruby-pwsh.git" # Change to another fork if desired

--- a/acceptance/Basic.Tests.ps1
+++ b/acceptance/Basic.Tests.ps1
@@ -219,7 +219,7 @@ Describe 'Acceptance Tests: Basic' -Tag @('Acceptance', 'Basic') {
                   '  dsc_network_access_allow_anonymous_sid_name_translation => "Disabled",'
                   "}`n"
                 ) -join "`n"
-                PdkSuccessFilterScript = { $_ -match 'Updating: Finished' }
+                PdkSuccessFilterScript = { $_ -match '(Updating: Finished|Applied catalog in)' }
                 PdkErrorFilterScript   = { $_ -match 'Error' }
               }
               @{
@@ -231,7 +231,7 @@ Describe 'Acceptance Tests: Basic' -Tag @('Acceptance', 'Basic') {
                   '  dsc_network_access_allow_anonymous_sid_name_translation => "Disabled",'
                   "}`n"
                 ) -join "`n"
-                PdkSuccessFilterScript = { $_ -match 'Updating: Finished' }
+                PdkSuccessFilterScript = { $_ -match '(Updating: Finished|Applied catalog in)' }
                 PdkErrorFilterScript   = { $_ -match 'Error' }
               }
               @{


### PR DESCRIPTION
Pinning ruby-pwsh version to a previous version to investigate the root of the broken CI.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.
